### PR TITLE
Update makePurchase example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When it comes time to make a purchase, _Purchases_ has a simple method, `makePur
 
 ```javascript
 Purchases.makePurchase("product_id", 
-  (productIdentifier, purchaserInfo) {
+  (productIdentifier, purchaserInfo) => {
     if (purchaserInfo.activeEntitlements.includes("my_entitlement_identifier")) {
       // Unlock that great "pro" content
     }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ func displayUpsellScreen() {
 When it comes time to make a purchase, _Purchases_ has a simple method, `makePurchase`. The code sample below shows the process of purchasing a product and confirming it unlocks the "my_entitlement_identifier" content.
 
 ```javascript
+const isSubscriptionProduct = ... // TODO: based on product_id
+
+// type is "subs" for subscriptions, "inapp" for non-subscriptions (e.g. consumables).
+const type = isSubscriptionProduct ? "subs" : "inapp";
+
 Purchases.makePurchase("product_id", 
   (productIdentifier, purchaserInfo) => {
     if (purchaserInfo.activeEntitlements.includes("my_entitlement_identifier")) {
@@ -92,9 +97,11 @@ Purchases.makePurchase("product_id",
   },
   error => {
     // Error making purchase
-  }
-})
+  },
+  [], // oldSkus, see docs for more details on when this is needed
+  type)
 ```
+
 
 > `makePurchase` handles the underlying framework interaction and automatically validates purchases with Apple and Google through our secure servers. This helps reduce in-app purchase fraud and decreases the complexity of your app. Receipt tokens are stored remotely and always kept up-to-date.
 


### PR DESCRIPTION
Forcing the code example to address the type parameter in makePurchase rather than rely on defaults.  I get that it's cleaner the other way, but I missed this the first time around and lost a day on it.

Also added missing "=>" in example code