### PR TITLE
Update makePurchase example to use updated API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Purchases.makePurchase(
   error => {
     // Error making purchase
   },
-  [], // Optional: oldSkus, see docs for more details on when this is needed
+  oldSku, // Optional: oldSku, see docs for more details on when this is needed
   type
 ); // Optional: Pass "subs" for subscriptions, "inapp" for non-subscriptions (e.g. consumables). Needed for Android, iOS will ignore this.
 ```


### PR DESCRIPTION
This API was updated to just take a string of the old SKU instead of an array, this PR just updates the README example to use the new API.