### PR TITLE
[final] bump: version 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.5
+
+- Adds `shouldPurchasePromoProduct`, which allows the app to decide how and when to handle promotional purchases made by users directly through the App Store (https://github.com/RevenueCat/cordova-plugin-purchases/pull/25). 
+- Fixes some JSDocs and export types https://github.com/RevenueCat/cordova-plugin-purchases/pull/26. 
+
 ## 1.0.4
 
 - Adds missing types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-purchases",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Purchases Cordova Plugin",
   "cordova": {
     "id": "cordova-plugin-purchases",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-purchases" version="1.0.4">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-purchases" version="1.0.5">
 
     <dependency id="cordova-annotated-plugin-android" />
 
@@ -16,7 +16,7 @@
                 <param name="android-package" value="com.revenuecat.purchases.PurchasesPlugin" />
             </feature>
         </config-file>
-        <framework src="com.revenuecat.purchases:purchases:3.0.4" />
+        <framework src="com.revenuecat.purchases:purchases:3.0.5" />
         <lib-file src="src/android/common-release.aar"/>
         <framework src="src/android/common.gradle" custom="true" type="gradleReference"/>
         <source-file src="src/android/PurchasesPlugin.java" target-dir="src/com/revenuecat/purchases"/>


### PR DESCRIPTION
Adds a bump for version 1.0.5, which includes the changes in https://github.com/RevenueCat/cordova-plugin-purchases/pull/25 and https://github.com/RevenueCat/cordova-plugin-purchases/pull/26