### PR TITLE
Update invalidatePurchaserInfoCache docs

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -877,11 +877,15 @@ class Purchases {
     }
     return false;
   }
-
   /**
    * Invalidates the cache for purchaser information.
-   * This is useful for cases where purchaser information might have been updated outside of the app, like if a
-   * promotional subscription is granted through the RevenueCat dashboard.
+   * 
+   * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+   * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+   * using the cache properly.
+   * 
+   * This is useful for cases where purchaser information might have been updated outside of the
+   * app, like if a promotional subscription is granted through the RevenueCat dashboard.
    */
   public static invalidatePurchaserInfoCache() {
     window.cordova.exec(

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -626,8 +626,13 @@ declare class Purchases {
     static removeShouldPurchasePromoProductListener(listenerToRemove: ShouldPurchasePromoProductListener): boolean;
     /**
      * Invalidates the cache for purchaser information.
-     * This is useful for cases where purchaser information might have been updated outside of the app, like if a
-     * promotional subscription is granted through the RevenueCat dashboard.
+     * 
+     * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * using the cache properly.
+     * 
+     * This is useful for cases where purchaser information might have been updated outside of the
+     * app, like if a promotional subscription is granted through the RevenueCat dashboard.
      */
     static invalidatePurchaserInfoCache(): void;
     /**

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -396,8 +396,13 @@ var Purchases = /** @class */ (function () {
     };
     /**
      * Invalidates the cache for purchaser information.
-     * This is useful for cases where purchaser information might have been updated outside of the app, like if a
-     * promotional subscription is granted through the RevenueCat dashboard.
+     * 
+     * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * using the cache properly.
+     * 
+     * This is useful for cases where purchaser information might have been updated outside of the
+     * app, like if a promotional subscription is granted through the RevenueCat dashboard.
      */
     Purchases.invalidatePurchaserInfoCache = function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "invalidatePurchaserInfoCache", []);


### PR DESCRIPTION
Invalidating the cache is simultaneously an advanced technique and attractive to beginners who might think they need to invalidate the cache on every app launch, so I added a link to our docs that explains how to work with the cache in normal circumstances.

This will update plugin.js, plugin.ts, plugin.d.ts.

See RevenueCat/purchases-ios#223