### PR TITLE
replaced deprecated framework tag with podspec tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,13 @@
         </config-file>
         <header-file src="src/ios/CDVPurchasesPlugin.h" />
         <source-file src="src/ios/CDVPurchasesPlugin.m" />
-        <framework src="Purchases" type="podspec" spec="3.3.1" />
-        <framework src="PurchasesHybridCommon" type="podspec" spec="1.1.0" />
+        <podspec>
+            <config>
+                <source url="https://github.com/CocoaPods/Specs.git"/>
+            </config>
+            <pods use-frameworks="true">
+                <pod name="PurchasesHybridCommon" spec="1.1.0" />
+            </pods>
+        </podspec>
     </platform>
 </plugin>


### PR DESCRIPTION
I noticed this line in the terminal while running:
```
"framework" tag with type "podspec" is deprecated and will be removed. Please use the "podspec" tag.
```

So I updated the plugin.xml file to use the new format for pods. 

I tried removing the ios platform, adding it again and running and it works as expected.
As usual, you can override the generated Podfile if you want to point to development versions of the plugin.