### PR TITLE
Update docs to match other hybrid SDKs

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1017,7 +1017,8 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the adjustID for the user
+   * Subscriber attribute associated with the Adjust Id for the user
+   * Required for the RevenueCat Adjust integration
    *
    * @param adjustID Empty String or null will delete the subscriber attribute.
    */
@@ -1032,8 +1033,8 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the appsflyerID for the user
-   *
+   * Subscriber attribute associated with the AppsFlyer Id for the user
+   * Required for the RevenueCat AppsFlyer integration
    * @param appsflyerID Empty String or null will delete the subscriber attribute.
    */
   public static setAppsflyerID(appsflyerID: string | null) { 
@@ -1047,7 +1048,8 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the fbAnonymousID for the user
+   * Subscriber attribute associated with the Facebook SDK Anonymous Id for the user
+   * Recommended for the RevenueCat Facebook integration
    *
    * @param fbAnonymousID Empty String or null will delete the subscriber attribute.
    */
@@ -1062,7 +1064,8 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the mparticleID for the user
+   * Subscriber attribute associated with the mParticle Id for the user
+   * Recommended for the RevenueCat mParticle integration
    *
    * @param mparticleID Empty String or null will delete the subscriber attribute.
    */
@@ -1077,7 +1080,8 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the onesignalID for the user
+   * Subscriber attribute associated with the OneSignal Player Id for the user
+   * Required for the RevenueCat OneSignal integration
    *
    * @param onesignalID Empty String or null will delete the subscriber attribute.
    */
@@ -1092,7 +1096,7 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the mediaSource for the user
+   * Subscriber attribute associated with the install media source for the user
    *
    * @param mediaSource Empty String or null will delete the subscriber attribute.
    */
@@ -1107,7 +1111,7 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the campaign for the user
+   * Subscriber attribute associated with the install campaign for the user
    *
    * @param campaign Empty String or null will delete the subscriber attribute.
    */
@@ -1122,7 +1126,7 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the adGroup for the user
+   * Subscriber attribute associated with the install ad group for the user
    *
    * @param adGroup Empty String or null will delete the subscriber attribute.
    */
@@ -1137,7 +1141,7 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with ad token for the user
+   * Subscriber attribute associated with the install ad for the user
    *
    * @param ad Empty String or null will delete the subscriber attribute.
    */
@@ -1152,7 +1156,7 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the keyword for the user
+   * Subscriber attribute associated with the install keyword for the user
    *
    * @param keyword Empty String or null will delete the subscriber attribute.
    */
@@ -1167,7 +1171,7 @@ class Purchases {
   }
   
   /**
-   * Subscriber attribute associated with the creative for the user
+   * Subscriber attribute associated with the install ad creative for the user
    *
    * @param creative Empty String or null will delete the subscriber attribute.
    */
@@ -1182,7 +1186,7 @@ class Purchases {
   }
 
   /**
-   * Automatically collect subscriber attributes associated with the device identifiers
+   * Automatically collect subscriber attributes associated with the device identifiers.
    * $idfa, $idfv, $ip on iOS
    * $gpsAdId, $androidId, $ip on Android
    */

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -710,73 +710,77 @@ declare class Purchases {
      */
     static setPushToken(pushToken: string | null): void;
     /**
-     * Subscriber attribute associated with the adjustID for the user
+     * Subscriber attribute associated with the Adjust Id for the user
+     * Required for the RevenueCat Adjust integration
      *
      * @param adjustID Empty String or null will delete the subscriber attribute.
      */
     static setAdjustID(adjustID: string | null): void;
     /**
-     * Subscriber attribute associated with the appsflyerID for the user
-     *
+     * Subscriber attribute associated with the AppsFlyer Id for the user
+     * Required for the RevenueCat AppsFlyer integration
      * @param appsflyerID Empty String or null will delete the subscriber attribute.
      */
     static setAppsflyerID(appsflyerID: string | null): void;
     /**
-     * Subscriber attribute associated with the fbAnonymousID for the user
+     * Subscriber attribute associated with the Facebook SDK Anonymous Id for the user
+     * Recommended for the RevenueCat Facebook integration
      *
      * @param fbAnonymousID Empty String or null will delete the subscriber attribute.
      */
     static setFBAnonymousID(fbAnonymousID: string | null): void;
     /**
-     * Subscriber attribute associated with the mparticleID for the user
+     * Subscriber attribute associated with the mParticle Id for the user
+     * Recommended for the RevenueCat mParticle integration
      *
      * @param mparticleID Empty String or null will delete the subscriber attribute.
      */
     static setMparticleID(mparticleID: string | null): void;
     /**
-     * Subscriber attribute associated with the onesignalID for the user
+     * Subscriber attribute associated with the OneSignal Player Id for the user
+     * Required for the RevenueCat OneSignal integration
      *
      * @param onesignalID Empty String or null will delete the subscriber attribute.
      */
     static setOnesignalID(onesignalID: string | null): void;
     /**
-     * Subscriber attribute associated with the mediaSource for the user
+     * Subscriber attribute associated with the install media source for the user
      *
      * @param mediaSource Empty String or null will delete the subscriber attribute.
      */
     static setMediaSource(mediaSource: string | null): void;
     /**
-     * Subscriber attribute associated with the campaign for the user
+     * Subscriber attribute associated with the install campaign for the user
      *
      * @param campaign Empty String or null will delete the subscriber attribute.
      */
     static setCampaign(campaign: string | null): void;
     /**
-     * Subscriber attribute associated with the adGroup for the user
+     * Subscriber attribute associated with the install ad group for the user
      *
      * @param adGroup Empty String or null will delete the subscriber attribute.
      */
     static setAdGroup(adGroup: string | null): void;
     /**
-     * Subscriber attribute associated with ad token for the user
+     * Subscriber attribute associated with the install ad for the user
      *
      * @param ad Empty String or null will delete the subscriber attribute.
      */
     static setAd(ad: string | null): void;
     /**
-     * Subscriber attribute associated with the keyword for the user
+     * Subscriber attribute associated with the install keyword for the user
      *
      * @param keyword Empty String or null will delete the subscriber attribute.
      */
     static setKeyword(keyword: string | null): void;
     /**
-     * Subscriber attribute associated with the creative for the user
+     * Subscriber attribute associated with the install ad creative for the user
      *
      * @param creative Empty String or null will delete the subscriber attribute.
      */
     static setCreative(creative: string | null): void;
     /**
-     * Automatically collect subscriber attributes associated with the device identifiers
+     * Automatically collect subscriber attributes associated with the device identifiers.
      * $idfa, $idfv, $ip on iOS
      * $gpsAdId, $androidId, $ip on Android
      */

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -459,7 +459,8 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setPushToken", [pushToken]);
     };
     /**
-     * Subscriber attribute associated with the adjustID for the user
+     * Subscriber attribute associated with the Adjust Id for the user
+     * Required for the RevenueCat Adjust integration
      *
      * @param adjustID Empty String or null will delete the subscriber attribute.
      */
@@ -467,15 +468,16 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setAdjustID", [adjustID]);
     };
     /**
-     * Subscriber attribute associated with the appsflyerID for the user
-     *
+     * Subscriber attribute associated with the AppsFlyer Id for the user
+     * Required for the RevenueCat AppsFlyer integration
      * @param appsflyerID Empty String or null will delete the subscriber attribute.
      */
     Purchases.setAppsflyerID = function (appsflyerID) {
         window.cordova.exec(null, null, PLUGIN_NAME, "setAppsflyerID", [appsflyerID]);
     };
     /**
-     * Subscriber attribute associated with the fbAnonymousID for the user
+     * Subscriber attribute associated with the Facebook SDK Anonymous Id for the user
+     * Recommended for the RevenueCat Facebook integration
      *
      * @param fbAnonymousID Empty String or null will delete the subscriber attribute.
      */
@@ -483,7 +485,8 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setFBAnonymousID", [fbAnonymousID]);
     };
     /**
-     * Subscriber attribute associated with the mparticleID for the user
+     * Subscriber attribute associated with the mParticle Id for the user
+     * Recommended for the RevenueCat mParticle integration
      *
      * @param mparticleID Empty String or null will delete the subscriber attribute.
      */
@@ -491,7 +494,8 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setMparticleID", [mparticleID]);
     };
     /**
-     * Subscriber attribute associated with the onesignalID for the user
+     * Subscriber attribute associated with the OneSignal Player Id for the user
+     * Required for the RevenueCat OneSignal integration
      *
      * @param onesignalID Empty String or null will delete the subscriber attribute.
      */
@@ -499,7 +503,7 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setOnesignalID", [onesignalID]);
     };
     /**
-     * Subscriber attribute associated with the mediaSource for the user
+     * Subscriber attribute associated with the install media source for the user
      *
      * @param mediaSource Empty String or null will delete the subscriber attribute.
      */
@@ -507,7 +511,7 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setMediaSource", [mediaSource]);
     };
     /**
-     * Subscriber attribute associated with the campaign for the user
+     * Subscriber attribute associated with the install campaign for the user
      *
      * @param campaign Empty String or null will delete the subscriber attribute.
      */
@@ -515,7 +519,7 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setCampaign", [campaign]);
     };
     /**
-     * Subscriber attribute associated with the adGroup for the user
+     * Subscriber attribute associated with the install ad group for the user
      *
      * @param adGroup Empty String or null will delete the subscriber attribute.
      */
@@ -523,7 +527,7 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setAdGroup", [adGroup]);
     };
     /**
-     * Subscriber attribute associated with ad token for the user
+     * Subscriber attribute associated with the install ad for the user
      *
      * @param ad Empty String or null will delete the subscriber attribute.
      */
@@ -531,7 +535,7 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setAd", [ad]);
     };
     /**
-     * Subscriber attribute associated with the keyword for the user
+     * Subscriber attribute associated with the install keyword for the user
      *
      * @param keyword Empty String or null will delete the subscriber attribute.
      */
@@ -539,7 +543,7 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setKeyword", [keyword]);
     };
     /**
-     * Subscriber attribute associated with the creative for the user
+     * Subscriber attribute associated with the install ad creative for the user
      *
      * @param creative Empty String or null will delete the subscriber attribute.
      */
@@ -547,7 +551,7 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setCreative", [creative]);
     };
     /**
-     * Automatically collect subscriber attributes associated with the device identifiers
+     * Automatically collect subscriber attributes associated with the device identifiers.
      * $idfa, $idfv, $ip on iOS
      * $gpsAdId, $androidId, $ip on Android
      */


### PR DESCRIPTION
Updates the docs for the new attribution subscriber attributes methods to match the more descriptive ones found in other hybrid SDKs. 

I missed this when opening https://github.com/RevenueCat/cordova-plugin-purchases/pull/56. 