### PR TITLE
Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
       - npm-dependencies
       - replace-api-key
-      - run: npm run test:ios -- --target:"iPhone 11 Pro (13.3)"
+      - run: cordova-paramedic --verbose --platform ios --plugin . --target:"iPhone-11-Pro, 13.3"
 
   runtest:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,160 @@
 version: 2.1
-jobs:
-  runtest:
-    macos:
-      xcode: "10.2.0"
-
+commands:
+  android-sdk-dependencies:
+    description: "Install and set android SDK"
     steps:
-      - checkout
+      - run:
+          name: set ANDROID_SDK_ROOT
+          command: |
+            echo 'export ANDROID_SDK_ROOT=$HOME/android-tools'  >> $BASH_ENV
+      - restore_cache:
+          key: android=tools-v1-{{ checksum "scripts/install-android-tools.sh" }}-{{ arch }}
 
-      # Download and cache dependencies
+      - run:
+          name: install android tools
+          command: |
+            sh scripts/install-android-tools.sh
+            echo 'export PATH=$ANDROID_SDK_ROOT/tools/bin:$PATH'  >> $BASH_ENV
+            echo 'export PATH=$ANDROID_SDK_ROOT/tools:$PATH'  >> $BASH_ENV
+            echo 'export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH'  >> $BASH_ENV
+            echo 'export PATH=$ANDROID_SDK_ROOT/emulator:$PATH'  >> $BASH_ENV
+            source $BASH_ENV
+            sdkmanager --list
+      - save_cache:
+          key: android=tools-v1-{{ checksum "scripts/install-android-tools.sh" }}-{{ arch }}
+          paths:
+            - /Users/distiller/android-tools
+
+  create-launch-android-emulator:
+    description: "create and launch android emulators"
+    steps:
+      - run:
+          name: create AVD
+          command: |
+            echo "no" | avdmanager --verbose create avd --force \
+              --name "Pixel_3a_API_26" \
+              --package "system-images;android-26;google_apis_playstore;x86"
+
+      - run:
+          name: start AVD
+          command: emulator @Pixel_3a_API_26 -no-window -no-audio
+          background: true
+
+      - run:
+          name: wait for emulator
+          command: |
+            adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+  
+  npm-dependencies:
+    description: "installs all global and local npm dependencies"
+    steps:
+      - run: npm install -g cordova
+      - run: npm install -g github:apache/cordova-paramedic
+      - run: npm install -g ios-deploy
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-
-      - run: yarn
-
+      - run: npm install
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+    
+  prepare-tests:
+    description: "prepares tests to run"
+    steps:
+      - run: sed -i .bck s/api_key/$API_KEY/ tests/tests.js
 
+  simulator-dependencies:
+    description: "Install iOS simulator dependencies"
+    steps:
+      - run:
+          name: "Install applesimutils"
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils
+  
+jobs:
+  checkout_code:
+    description: "Checkout code"
+    macos:
+      xcode: 11.3.1
+    steps:
+      - checkout
+      - persist_to_workspace:
+          paths: .
+          root: .
+  
+  android-integration-test:
+    description: "Run Android integration tests for Flutter"
+    macos:
+      xcode: 11.3.1
+    steps:
+      - attach_workspace:
+          at: .
+      - run: ls
+      - run: brew install gradle
+      - android-sdk-dependencies
+      - create-launch-android-emulator
+      - npm-dependencies
+      - prepare-tests
+      - run: npm run test:android
+
+  ios-integration-test:
+    description: "Run iOS integration tests for Flutter"
+    macos:
+      xcode: 11.3.1
+    steps:
+      - attach_workspace:
+          at: .
+      - simulator-dependencies
+      - run:
+          name: Open simulator
+          command: xcrun simctl boot "iPhone 11"
+      - npm-dependencies
+      - prepare-tests
+      - run: npm run test:ios
+
+  runtest:
+    macos:
+      xcode: 11.3.1
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: yarn
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
       - run: yarn test
-
       - run: yarn tslint
-
       - run:
           name: Build
           command: |
             yarn build
+
 workflows:
   version: 2
   build-test:
     jobs:
       - runtest
+  
+  android-integration-test:
+    jobs:
+      - checkout_code
+      - android-integration-test:
+          requires:
+            - checkout_code
+  
+  ios-integration-test:
+    jobs:
+      - checkout_code
+      - ios-integration-test:
+          requires:
+            - checkout_code
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
   android-integration-test:
     description: "Run Android integration tests for Flutter"
     macos:
-      xcode: 12.2.0
+      xcode: 11.3.1
     steps:
       - checkout
       - run: brew install gradle
@@ -89,7 +89,7 @@ jobs:
   ios-integration-test:
     description: "Run iOS integration tests for Flutter"
     macos:
-      xcode: 12.2.0
+      xcode: 11.3.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,10 @@
+release-tags-and-branches: &release-tags-and-branches
+  filters:
+    tags:
+      ignore: /^.*-SNAPSHOT/
+    branches:
+      only: /^release\/.*/
+
 version: 2.1
 commands:
   android-sdk-dependencies:
@@ -122,21 +129,9 @@ workflows:
   
   android-integration-test:
     jobs:
-      - android-integration-test:
-          filters:
-            tags:
-              only: /^(\d+\.)(\d+\.)(\d+)$/
-#            Uncomment before merging
-#            branches:
-#              only: /^release\/(\d+\.)(\d+\.)(\d+)$/
+      - android-integration-test: *release-tags-and-branches
   
   ios-integration-test:
     jobs:
-      - ios-integration-test:
-          filters:
-            tags:
-              only: /^(\d+\.)(\d+\.)(\d+)$/
-#            Uncomment before merging
-#            branches:
-#              only: /^release\/(\d+\.)(\d+\.)(\d+)$/
+      - ios-integration-test: *release-tags-and-branches
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
       - npm-dependencies
       - replace-api-key
-      - run: cordova-paramedic --verbose --platform ios --plugin . --target:"iPhone-11-Pro, 13.3"
+      - run: npm run test:ios
 
   runtest:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
       - run: npm run test:ios
 
   runtest:
-    macos:
-      xcode: 12.2.0
+    docker:
+      - image: circleci/node:lts
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,20 +60,11 @@ commands:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
     
-  prepare-tests:
-    description: "prepares tests to run"
+  replace-api-key:
+    description: "replace API_KEY"
     steps:
       - run: sed -i .bck s/api_key/$API_KEY/ tests/tests.js
 
-  simulator-dependencies:
-    description: "Install iOS simulator dependencies"
-    steps:
-      - run:
-          name: "Install applesimutils"
-          command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils
-  
 jobs:
   android-integration-test:
     description: "Run Android integration tests for Flutter"
@@ -85,8 +76,8 @@ jobs:
       - android-sdk-dependencies
       - create-launch-android-emulator
       - npm-dependencies
-      - prepare-tests
-      - run: npm run test:android
+      - replace-api-key
+      - run: npm run test:android -- --target:"iPhone 11 Pro (13.3)"
 
   ios-integration-test:
     description: "Run iOS integration tests for Flutter"
@@ -95,10 +86,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Open simulator
+          name: Start simulator
           command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
       - npm-dependencies
-      - prepare-tests
+      - replace-api-key
       - run: npm run test:ios
 
   runtest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - create-launch-android-emulator
       - npm-dependencies
       - replace-api-key
-      - run: npm run test:android -- --target:"iPhone 11 Pro (13.3)"
+      - run: npm run test:android
 
   ios-integration-test:
     description: "Run iOS integration tests for Flutter"
@@ -90,7 +90,7 @@ jobs:
           command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
       - npm-dependencies
       - replace-api-key
-      - run: npm run test:ios
+      - run: npm run test:ios -- --target:"iPhone 11 Pro (13.3)"
 
   runtest:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
   android-integration-test:
     description: "Run Android integration tests for Flutter"
     macos:
-      xcode: 11.3.1
+      xcode: 12.2.0
     steps:
       - checkout
       - run: brew install gradle
@@ -82,7 +82,7 @@ jobs:
   ios-integration-test:
     description: "Run iOS integration tests for Flutter"
     macos:
-      xcode: 11.3.1
+      xcode: 12.2.0
     steps:
       - checkout
       - run:
@@ -94,7 +94,7 @@ jobs:
 
   runtest:
     macos:
-      xcode: 11.3.1
+      xcode: 12.2.0
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,10 @@ commands:
             echo 'export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH'  >> $BASH_ENV
             echo 'export PATH=$ANDROID_SDK_ROOT/emulator:$PATH'  >> $BASH_ENV
             source $BASH_ENV
-            sdkmanager --list
       - save_cache:
           key: android=tools-v1-{{ checksum "scripts/install-android-tools.sh" }}-{{ arch }}
           paths:
-            - /Users/distiller/android-tools
+            - ~/android-tools
 
   create-launch-android-emulator:
     description: "create and launch android emulators"
@@ -76,24 +75,12 @@ commands:
             HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils
   
 jobs:
-  checkout_code:
-    description: "Checkout code"
-    macos:
-      xcode: 11.3.1
-    steps:
-      - checkout
-      - persist_to_workspace:
-          paths: .
-          root: .
-  
   android-integration-test:
     description: "Run Android integration tests for Flutter"
     macos:
       xcode: 11.3.1
     steps:
-      - attach_workspace:
-          at: .
-      - run: ls
+      - checkout
       - run: brew install gradle
       - android-sdk-dependencies
       - create-launch-android-emulator
@@ -106,12 +93,10 @@ jobs:
     macos:
       xcode: 11.3.1
     steps:
-      - attach_workspace:
-          at: .
-      - simulator-dependencies
+      - checkout
       - run:
           name: Open simulator
-          command: xcrun simctl boot "iPhone 11"
+          command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
       - npm-dependencies
       - prepare-tests
       - run: npm run test:ios
@@ -146,15 +131,21 @@ workflows:
   
   android-integration-test:
     jobs:
-      - checkout_code
       - android-integration-test:
-          requires:
-            - checkout_code
+          filters:
+            tags:
+              only: /^(\d+\.)(\d+\.)(\d+)$/
+#            Uncomment before merging
+#            branches:
+#              only: /^release\/(\d+\.)(\d+\.)(\d+)$/
   
   ios-integration-test:
     jobs:
-      - checkout_code
       - ios-integration-test:
-          requires:
-            - checkout_code
+          filters:
+            tags:
+              only: /^(\d+\.)(\d+\.)(\d+)$/
+#            Uncomment before merging
+#            branches:
+#              only: /^release\/(\d+\.)(\d+\.)(\d+)$/
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "build": "tsc",
     "build-watch": "tsc --watch",
     "tslint": "tslint -c tslint.json 'src/plugin/*.ts'",
-    "test": "jest"
+    "test": "jest",
+    "test:android": "cordova-paramedic --verbose --platform android --plugin .",
+    "test:ios": "cordova-paramedic --verbose --platform ios --plugin ."
   },
   "author": "RevenueCat, Inc.",
   "license": "MIT",

--- a/scripts/install-android-tools.sh
+++ b/scripts/install-android-tools.sh
@@ -1,0 +1,28 @@
+if [ -d $ANDROID_SDK_ROOT ]
+then
+    echo "Directory $ANDROID_SDK_ROOT already exists so we're skipping the install. If you'd like to install fresh tools, edit this script to invalidate the CI cache."
+    exit 0
+fi
+
+mkdir -p $ANDROID_SDK_ROOT
+cd $ANDROID_SDK_ROOT
+curl https://dl.google.com/android/repository/sdk-tools-darwin-4333796.zip -o sdk-tools.zip
+
+unzip sdk-tools.zip
+
+mkdir -p "$ANDROID_SDK_ROOT/licenses"
+
+echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_SDK_ROOT/licenses/android-sdk-license"
+echo "84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_SDK_ROOT/licenses/android-sdk-preview-license"
+echo "d975f751698a77b662f1254ddbeed3901e976f5a" > "$ANDROID_SDK_ROOT/licenses/intel-android-extra-license"
+
+SDKMANAGER=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
+
+$SDKMANAGER "platform-tools"
+$SDKMANAGER "platforms;android-29"
+$SDKMANAGER "build-tools;29.0.2"
+$SDKMANAGER "ndk-bundle"
+$SDKMANAGER "system-images;android-26;google_apis_playstore;x86"
+$SDKMANAGER "emulator"
+
+echo "y" | sudo $SDKMANAGER --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cordova-plugin-purchases-tests",
+  "version": "1.3.1",
+  "description": "",
+  "cordova": {
+    "id": "cordova-plugin-purchases-tests",
+    "platforms": []
+  },
+  "keywords": [
+    "cordova",
+    "ecosystem:cordova",
+    "cordova-ios",
+    "cordova-android"
+  ],
+  "author": "RevenueCat, Inc.",
+  "license": "MIT"
+}

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-purchases-tests" version="1.3.2">
+    
+    <dependency id="cordova-plugin-androidx" />
+    <dependency id="cordova-plugin-add-swift-support" />
+
+    <name>Purchases Tests</name>
+    <license>MIT</license>
+    <js-module src="tests.js" name="tests"></js-module>
+</plugin>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,36 @@
+exports.defineAutoTests = function() {
+  describe("Purchases (Purchases)", function() {
+    beforeAll(function() {
+      Purchases.setup("api_key");
+    });
+
+    it("should exist", function() {
+      expect(Purchases).toBeDefined();
+    });
+
+    it("should configure without crashing", function(done) {
+      Purchases.getAppUserID(
+        appUserID => {
+          console.log(Purchases.appUserID);
+          expect(appUserID).toBeTruthy();
+          done();
+        },
+        error => {
+          done.fail("shouldn't be error");
+        }
+      );
+    });
+
+    it("should get purchaser info", function(done) {
+      Purchases.getPurchaserInfo(
+        info => {
+          expect(info).toBeTruthy();
+          done();
+        },
+        error => {
+          done.fail("shouldn't be error");
+        }
+      );
+    }, 10000);
+  });
+};


### PR DESCRIPTION
- Adds two job to CircleCI
  - android-integration-test: runs a simple test on an emulator to verify the SDK can be configured, an appUserID is assigned and purchaserInfo can be fetched
  - ios-integration-test: same as the Android test but on an iOS simulator

- The api key is passed via an env variable configured in CircleCI.
- The UpsellScreen in the example now takes care of fetching offerings itself and this is not done when loading the App anymore.
- We use cordova-paramedic for the tests, which will basically create a new project and add our plugin. It runs our tests on that project afterwards
