### PR TITLE
Enable androidx and swift support plugin in example

### DIFF
--- a/examples/cordova-sample/MyApp/config.xml
+++ b/examples/cordova-sample/MyApp/config.xml
@@ -23,4 +23,5 @@
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
     </platform>
+    <preference name="AndroidXEnabled" value="true" />
 </widget>

--- a/examples/cordova-sample/MyApp/package-lock.json
+++ b/examples/cordova-sample/MyApp/package-lock.json
@@ -2169,9 +2169,9 @@
           }
         },
         "execa": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -2227,13 +2227,21 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
           }
         },
         "mimic-fn": {
@@ -2786,13 +2794,21 @@
           }
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
           }
         },
         "nopt": {
@@ -3087,6 +3103,35 @@
             "is-typedarray": "^1.0.0",
             "signal-exit": "^3.0.2",
             "typedarray-to-buffer": "^3.1.5"
+          }
+        }
+      }
+    },
+    "cordova-plugin-add-swift-support": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-add-swift-support/-/cordova-plugin-add-swift-support-2.0.2.tgz",
+      "integrity": "sha512-K03WDnsD3GT+n7Od3BnS17D8rYnAFZbZjjQJa2r7qW8QLq8+h7hGbFaiF+w5+nUtyAqUNq+HT/d/MdqBGLNzxA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "semver": "^6.0.0",
+        "xcode": "^2.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "xcode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/xcode/-/xcode-2.1.0.tgz",
+          "integrity": "sha512-uCrmPITrqTEzhn0TtT57fJaNaw8YJs1aCzs+P/QqxsDbvPZSv7XMPPwXrKvHtD6pLjBM/NaVwraWJm8q83Y4iQ==",
+          "dev": true,
+          "requires": {
+            "simple-plist": "^1.0.0",
+            "uuid": "^3.3.2"
           }
         }
       }

--- a/examples/cordova-sample/MyApp/package.json
+++ b/examples/cordova-sample/MyApp/package.json
@@ -23,15 +23,15 @@
     "plugins": {
       "cordova-plugin-whitelist": {},
       "cordova-annotated-plugin-android": {},
-      "cordova-plugin-purchases": {}
+      "cordova-plugin-add-swift-support": {}
     },
     "platforms": [
-      "ios",
       "android"
     ]
   },
   "devDependencies": {
     "cordova-android": "^9.0.0",
-    "cordova-ios": "^6.1.1"
+    "cordova-ios": "^6.1.1",
+    "cordova-plugin-add-swift-support": "^2.0.2"
   }
 }

--- a/examples/cordova-sample/MyApp/package.json
+++ b/examples/cordova-sample/MyApp/package.json
@@ -23,9 +23,11 @@
     "plugins": {
       "cordova-plugin-whitelist": {},
       "cordova-annotated-plugin-android": {},
+      "cordova-plugin-purchases": {},
       "cordova-plugin-add-swift-support": {}
     },
     "platforms": [
+      "ios",
       "android"
     ]
   },


### PR DESCRIPTION
With `"cordova-android": "^9.0.0"` there is a new preference `AndroidXEnabled` that enables AndroidX. I also added the `cordova-plugin-add-swift-support` plugin because I was getting the `error: Value for SWIFT_VERSION cannot be empty.` error when building the project