### PR TITLE
Patch 2.0.0 to fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,13 @@ commands:
       - run: npm install -g ios-deploy
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
+            - v2-dependencies-{{ checksum "package.json" }}
+            - v2-dependencies-
       - run: npm install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v2-dependencies-{{ checksum "package.json" }}
     
   replace-api-key:
     description: "replace API_KEY"


### PR DESCRIPTION
I believe the problem is that the cache was created in another working directory, or machine or something like that, and the restore is failing. I have invalidated the cache by updating the key to v2