### PR TITLE
Dependency broke us, update TypeScript

### DIFF
--- a/examples/cordova-sample/MyApp/README.md
+++ b/examples/cordova-sample/MyApp/README.md
@@ -15,21 +15,29 @@ sed -i .bck s/api_key/<your_api_key>/ www/js/index.js
 ```
 
 
-2. iOS
+3. Coreutils
+
+Use homebrew to install coreutils
+
+```bash
+brew install coreutils
+```
+
+4. iOS
 
 Edit the project settings in Xcode: 
 Add a Run Script Build Phase, name it "Refresh Javascript Sources"
 Add the following code: 
 
 ```bash
-sh ../../bin/refresh_javascript_sources_ios.sh
+sh $PROJECT_DIR/../../bin/refresh_javascript_sources_ios.sh
 ```
 
 You're ready to go! 
 
 #### when making changes: 
 
-##### In Obj-C code:
+##### In Swift code:
 
 You can just make the edits straight from Xcode or AppCode, then build and you're good. 
 

--- a/examples/cordova-sample/MyApp/bin/refresh_javascript_sources_ios.sh
+++ b/examples/cordova-sample/MyApp/bin/refresh_javascript_sources_ios.sh
@@ -1,3 +1,17 @@
+#!/bin/bash
+# Environment detection
+if [ "$(uname -p)" = "i386" ]; then
+  echo "Running in i386 mode"
+  eval "$(/usr/local/homebrew/bin/brew shellenv)"
+  alias brew='/usr/local/homebrew/bin/brew'
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  eval "$(pyenv init --path)"
+else
+  echo "Running in ARM mode"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+  alias brew='/opt/homebrew/bin/brew'
+fi
 # in case this script is run from another directory, cd into the directory of the script
 SCRIPT_DIRECTORY="$(dirname "$(realpath "$0")")"
 

--- a/examples/cordova-sample/MyApp/package.json
+++ b/examples/cordova-sample/MyApp/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "devDependencies": {
-    "cordova-android": "^9.1.0",
+    "cordova-android": "^10.1.2",
     "cordova-ios": "^6.2.0",
     "cordova-plugin-add-swift-support": "^2.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "author": "RevenueCat, Inc.",
   "license": "MIT",
   "devDependencies": {
-    "@types/jest": "^26.0.24",
+    "@types/jest": "^27.1.5",
     "@types/node": "^12.6.8",
     "jest": "^27.0.0",
     "prettier": "1.18.2",
     "ts-jest": "^27.0.0-next.12",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.5.3"
+    "typescript": "^4.2.0"
   }
 }

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -139,7 +139,6 @@ export interface PurchasesEntitlementInfo {
     readonly isActive: boolean;
     /**
      * True if the underlying subscription is set to renew at the end of the billing period (expirationDate).
-     * Will always be True if entitlement is for lifetime access.
      */
     readonly willRenew: boolean;
     /**


### PR DESCRIPTION
Dependency broke us: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60310
Upgrade to newer TypeScript anyway since we're in the process of bringing this plugin up to the most recent RevenueCat SDK releases.