### PR TITLE
Update Purchaser/Customer related naming -> Rename of old API before adding in new API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/cordova-sample/MyApp/node_modules
 examples/cordova-sample/MyApp/platforms
 examples/cordova-sample/MyApp/plugins
 package-lock.json
+*.bck

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn.lock
 examples/cordova-sample/MyApp/node_modules
 examples/cordova-sample/MyApp/platforms
 examples/cordova-sample/MyApp/plugins
+package-lock.json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,11 @@ GEM
       rexml (~> 3.2.4)
 
 PLATFORMS
+  arm64-darwin-20
   arm64-darwin-21
 
 DEPENDENCIES
   xcodeproj
 
 BUNDLED WITH
-   2.2.32
+   2.3.17

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -82,6 +82,7 @@ const app = {
         }
     );
 
+    // TODO: Used during development of next major, remove before release.
     Purchases.invalidateCustomerInfoCache();
 
     Purchases.getOfferings(

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -25,7 +25,7 @@ const app = {
       this.onDeviceReady.bind(this),
       false
     );
-    window.addEventListener("onPurchaserInfoUpdated", (info) => {
+    window.addEventListener("onCustomerInfoUpdated", (info) => {
 
     });
   },
@@ -64,7 +64,7 @@ const app = {
     console.log("---------");
     Purchases.setDebugLogsEnabled(true);
     Purchases.setup("api_key");
-    Purchases.getPurchaserInfo(
+    Purchases.getCustomerInfo(
       info => {
         const isPro = typeof info.entitlements.active.pro_cat !== "undefined";
         console.log("isPro " + JSON.stringify(isPro));
@@ -81,6 +81,8 @@ const app = {
         console.log("ISANONYMOUS " + isAnonymous);
         }
     );
+
+    Purchases.invalidateCustomerInfoCache();
 
     Purchases.getOfferings(
       offerings => {

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -131,8 +131,8 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         callbackContext.success(CommonKt.getAppUserID());
     }
 
-    @PluginAction(thread = ExecutionThread.UI, actionName = "restoreTransactions", isAutofinish = false)
-    private void restoreTransactions(CallbackContext callbackContext) {
+    @PluginAction(thread = ExecutionThread.UI, actionName = "restorePurchases", isAutofinish = false)
+    private void restorePurchases(CallbackContext callbackContext) {
         CommonKt.restorePurchases(getOnResult(callbackContext));
     }
 
@@ -146,8 +146,8 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         CommonKt.logOut(getOnResult(callbackContext));
     }
 
-    @PluginAction(thread = ExecutionThread.UI, actionName = "getPurchaserInfo", isAutofinish = false)
-    private void getPurchaserInfo(CallbackContext callbackContext) {
+    @PluginAction(thread = ExecutionThread.UI, actionName = "getCustomerInfo", isAutofinish = false)
+    private void getCustomerInfo(CallbackContext callbackContext) {
         CommonKt.getCustomerInfo(getOnResult(callbackContext));
     }
 
@@ -191,8 +191,8 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         callbackContext.success(convertMapToJson(map));
     }
     
-    @PluginAction(thread = ExecutionThread.WORKER, actionName = "invalidatePurchaserInfoCache")
-    private void invalidatePurchaserInfoCache(CallbackContext callbackContext) {
+    @PluginAction(thread = ExecutionThread.WORKER, actionName = "invalidateCustomerInfoCache")
+    private void invalidateCustomerInfoCache(CallbackContext callbackContext) {
         CommonKt.invalidateCustomerInfoCache();
         callbackContext.success();
     }

--- a/src/ios/PurchasesPlugin.swift
+++ b/src/ios/PurchasesPlugin.swift
@@ -116,8 +116,8 @@ public class CDVPurchasesPlugin : CDVPlugin {
                                      completion: self.responseCompletion(forCommand: command))
     }
 
-    @objc(restoreTransactions:)
-    func restoreTransactions(command: CDVInvokedUrlCommand) {
+    @objc(restorePurchases:)
+    func restorePurchases(command: CDVInvokedUrlCommand) {
         CommonFunctionality.restorePurchases(completion: self.responseCompletion(forCommand: command))
     }
 
@@ -159,8 +159,8 @@ public class CDVPurchasesPlugin : CDVPlugin {
         self.sendOKFor(command: command)
     }
 
-    @objc(getPurchaserInfo:)
-    func getPurchaserInfo(command: CDVInvokedUrlCommand) {
+    @objc(getCustomerInfo:)
+    func getCustomerInfo(command: CDVInvokedUrlCommand) {
         CommonFunctionality.customerInfo(completion: self.responseCompletion(forCommand: command))
     }
 
@@ -215,8 +215,8 @@ public class CDVPurchasesPlugin : CDVPlugin {
     }
 
     // Update name
-    @objc(invalidatePurchaserInfoCache:)
-    func invalidatePurchaserInfoCache(command: CDVInvokedUrlCommand) {
+    @objc(invalidateCustomerInfoCache:)
+    func invalidateCustomerInfoCache(command: CDVInvokedUrlCommand) {
         CommonFunctionality.invalidateCustomerInfoCache()
         self.sendOKFor(command: command)
     }
@@ -354,7 +354,6 @@ public class CDVPurchasesPlugin : CDVPlugin {
 
     @objc(canMakePayments:)
     func canMakePayments(command: CDVInvokedUrlCommand) {
-        // The implementation of this method does nothing with `features`.
         let canMakePayments = CommonFunctionality.canMakePaymentsWithFeatures([])
         let result = CDVPluginResult(status: .ok, messageAs: canMakePayments)
         self.commandDelegate.send(result, callbackId: command.callbackId)

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -240,7 +240,7 @@ export interface PurchasesTransaction {
   readonly purchaseDate: string;
 }
 
-export interface PurchaserInfo {
+export interface CustomerInfo {
   /**
    * Entitlements attached to this purchaser info
    */
@@ -482,9 +482,9 @@ export interface IntroEligibility {
  */
 export interface LogInResult {
   /**
-   * The Purchaser Info for the user.
+   * The Customer Info for the user.
    */
-  readonly purchaserInfo: PurchaserInfo;
+  readonly customerInfo: CustomerInfo;
   /**
    * True if the call resulted in a new user getting created in the RevenueCat backend.
    */
@@ -564,8 +564,8 @@ class Purchases {
     userDefaultsSuiteName?: string
   ): void {
     window.cordova.exec(
-      (purchaserInfo: any) => {
-        window.cordova.fireWindowEvent("onPurchaserInfoUpdated", purchaserInfo);
+      (customerInfo: any) => {
+        window.cordova.fireWindowEvent("onCustomerInfoUpdated", customerInfo);
       },
       null,
       PLUGIN_NAME,
@@ -657,7 +657,7 @@ class Purchases {
    * Make a purchase
    *
    * @param {string} productIdentifier The product identifier of the product you want to purchase.
-   * @param {function(string, PurchaserInfo):void} callback Callback triggered after a successful purchase.
+   * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchase.
    * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error or when the user cancels the purchase.
    * If user cancelled, userCancelled will be true
    * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
@@ -666,7 +666,7 @@ class Purchases {
    */
   public static purchaseProduct(
     productIdentifier: string,
-    callback: ({productIdentifier, purchaserInfo,}: { productIdentifier: string; purchaserInfo: PurchaserInfo; }) => void,
+    callback: ({productIdentifier, customerInfo,}: { productIdentifier: string; customerInfo: CustomerInfo; }) => void,
     errorCallback: ({error, userCancelled,}: { error: PurchasesError; userCancelled: boolean; }) => void,
     upgradeInfo?: UpgradeInfo | null,
     type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
@@ -697,7 +697,7 @@ class Purchases {
    * Make a purchase
    *
    * @param {PurchasesPackage} aPackage The Package you wish to purchase. You can get the Packages by calling getOfferings
-   * @param {function(string, PurchaserInfo):void} callback Callback triggered after a successful purchase.
+   * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchase.
    * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error or when the user cancels the purchase.
    * If user cancelled, userCancelled will be true
    * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
@@ -705,7 +705,7 @@ class Purchases {
    */
   public static purchasePackage(
     aPackage: PurchasesPackage,
-    callback: ({productIdentifier, purchaserInfo,}: { productIdentifier: string; purchaserInfo: PurchaserInfo; }) => void,
+    callback: ({productIdentifier, customerInfo,}: { productIdentifier: string; customerInfo: CustomerInfo; }) => void,
     errorCallback: ({error, userCancelled,}: { error: PurchasesError; userCancelled: boolean; }) => void,
     upgradeInfo?: UpgradeInfo | null
   ) {
@@ -735,19 +735,19 @@ class Purchases {
 
   /**
    * Restores a user's previous purchases and links their appUserIDs to any user's also using those purchases.
-   * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after restoring transactions.
+   * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after restoring transactions.
    * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem restoring the user transactions. This gets normally triggered if there
    * is an error retrieving the new purchaser info for the new user or the user cancelled the restore
    */
-  public static restoreTransactions(
-    callback: (purchaserInfo: PurchaserInfo) => void,
+  public static restorePurchases(
+    callback: (customerInfo: CustomerInfo) => void,
     errorCallback: (error: PurchasesError) => void
   ) {
     window.cordova.exec(
       callback,
       errorCallback,
       PLUGIN_NAME,
-      "restoreTransactions",
+      "restorePurchases",
       []
     );
   }
@@ -764,7 +764,7 @@ class Purchases {
    * This function will logIn the current user with an appUserID. Typically this would be used after a log in 
    * to identify a user without calling configure.
    * @param {String} appUserID The appUserID that should be linked to the currently user
-   * @param {function(LogInResult):void} callback Callback that will receive an object that contains the purchaserInfo after logging in, as well as a boolean indicating 
+   * @param {function(LogInResult):void} callback Callback that will receive an object that contains the customerInfo after logging in, as well as a boolean indicating 
    * whether the user has just been created for the first time in the RevenueCat backend. 
    * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem logging in.
    */
@@ -785,12 +785,12 @@ class Purchases {
   /**
    * Logs out the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
    * If the current user is already anonymous, this will produce a PurchasesError.
-   * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after resetting
+   * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after resetting
    * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is an error when logging out. 
    * This could happen for example if logOut is called but the current user is anonymous.
    */
   public static logOut(
-    callback: (purchaserInfo: PurchaserInfo) => void,
+    callback: (customerInfo: CustomerInfo) => void,
     errorCallback: (error: PurchasesError) => void
   ) {
     window.cordova.exec(callback, errorCallback, PLUGIN_NAME, "logOut", []);
@@ -801,13 +801,13 @@ class Purchases {
    * @deprecated, use logIn instead.
    * This function will alias two appUserIDs together.
    * @param {string} newAppUserID The new appUserID that should be linked to the currently identified appUserID. Needs to be a string.
-   * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after creating the alias
+   * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after creating the alias
    * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem creating the alias. This gets normally triggered if there
    * is an error retrieving the new purchaser info for the new user or there is an error creating the alias.
    */
   public static createAlias(
     newAppUserID: string,
-    callback: (purchaserInfo: PurchaserInfo) => void,
+    callback: (customerInfo: CustomerInfo) => void,
     errorCallback: (error: PurchasesError) => void
   ) {
     // noinspection SuspiciousTypeOfGuard
@@ -823,13 +823,13 @@ class Purchases {
    * @deprecated, use logIn instead.
    * This function will identify the current user with an appUserID. Typically this would be used after a logout to identify a new user without calling configure
    * @param {string} newAppUserID The appUserID that should be linked to the currently user
-   * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after identifying.
+   * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after identifying.
    * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem identifying the new user. This gets normally triggered if there
    * is an error retrieving the new purchaser info for the new user.
    */
   public static identify(
     newAppUserID: string,
-    callback: (purchaserInfo: PurchaserInfo) => void,
+    callback: (customerInfo: CustomerInfo) => void,
     errorCallback: (error: PurchasesError) => void
   ) {
     // noinspection SuspiciousTypeOfGuard
@@ -844,32 +844,32 @@ class Purchases {
   /**
    * @deprecated, use logOut instead.
    * Resets the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
-   * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after resetting
+   * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after resetting
    * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem resetting the SDK. This gets normally triggered if there
    * is an error retrieving the new purchaser info for the new user.
    */
   public static reset(
-    callback: (purchaserInfo: PurchaserInfo) => void,
+    callback: (customerInfo: CustomerInfo) => void,
     errorCallback: (error: PurchasesError) => void
   ) {
     window.cordova.exec(callback, errorCallback, PLUGIN_NAME, "reset", []);
   }
 
   /**
-   * Gets the current purchaser info. This call will return the cached purchaser info unless the cache is stale, in which case,
+   * Gets the current customer info. This call will return the cached customer info unless the cache is stale, in which case,
    * it will make a network call to retrieve it from the servers.
-   * @param {function(PurchaserInfo):void} callback Callback that will receive the purchaser info
-   * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem retrieving the purchaser info
+   * @param {function(CustomerInfo):void} callback Callback that will receive the purchaser info
+   * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem retrieving the customer info
    */
-  public static getPurchaserInfo(
-    callback: (purchaserInfo: PurchaserInfo) => void,
+  public static getCustomerInfo(
+    callback: (customerInfo: CustomerInfo) => void,
     errorCallback: (error: PurchasesError) => void
   ) {
     window.cordova.exec(
       callback,
       errorCallback,
       PLUGIN_NAME,
-      "getPurchaserInfo",
+      "getCustomerInfo",
       []
     );
   }
@@ -979,7 +979,7 @@ class Purchases {
     return false;
   }
   /**
-   * Invalidates the cache for purchaser information.
+   * Invalidates the cache for customer information.
    * 
    * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
    * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
@@ -988,12 +988,12 @@ class Purchases {
    * This is useful for cases where purchaser information might have been updated outside of the
    * app, like if a promotional subscription is granted through the RevenueCat dashboard.
    */
-  public static invalidatePurchaserInfoCache(): void {
+  public static invalidateCustomerInfoCache(): void {
     window.cordova.exec(
       null,
       null,
       PLUGIN_NAME,
-      "invalidatePurchaserInfoCache",
+      "invalidateCustomerInfoCache",
       []
     );
   }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -982,7 +982,7 @@ class Purchases {
    * Invalidates the cache for customer information.
    * 
    * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
-   * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+   * Refer to https://docs.revenuecat.com/docs/customer-info#section-get-user-information for more information on
    * using the cache properly.
    * 
    * This is useful for cases where purchaser information might have been updated outside of the

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -22,7 +22,7 @@ exports.defineAutoTests = function() {
     });
 
     it("should get purchaser info", function(done) {
-      Purchases.getPurchaserInfo(
+      Purchases.getCustomerInfo(
         info => {
           expect(info).toBeTruthy();
           done();

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -718,7 +718,7 @@ declare class Purchases {
      * Invalidates the cache for customer information.
      *
      * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
-     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * Refer to https://docs.revenuecat.com/docs/customer-info#section-get-user-information for more information on
      * using the cache properly.
      *
      * This is useful for cases where purchaser information might have been updated outside of the

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -215,7 +215,7 @@ export interface PurchasesTransaction {
      */
     readonly purchaseDate: string;
 }
-export interface PurchaserInfo {
+export interface CustomerInfo {
     /**
      * Entitlements attached to this purchaser info
      */
@@ -455,9 +455,9 @@ export interface IntroEligibility {
  */
 export interface LogInResult {
     /**
-     * The Purchaser Info for the user.
+     * The Customer Info for the user.
      */
-    readonly purchaserInfo: PurchaserInfo;
+    readonly customerInfo: CustomerInfo;
     /**
      * True if the call resulted in a new user getting created in the RevenueCat backend.
      */
@@ -559,16 +559,16 @@ declare class Purchases {
      * Make a purchase
      *
      * @param {string} productIdentifier The product identifier of the product you want to purchase.
-     * @param {function(string, PurchaserInfo):void} callback Callback triggered after a successful purchase.
+     * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchase.
      * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error or when the user cancels the purchase.
      * If user cancelled, userCancelled will be true
      * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
      * and the optional prorationMode.
      * @param {PURCHASE_TYPE} type Optional type of product, can be inapp or subs. Subs by default
      */
-    static purchaseProduct(productIdentifier: string, callback: ({ productIdentifier, purchaserInfo, }: {
+    static purchaseProduct(productIdentifier: string, callback: ({ productIdentifier, customerInfo, }: {
         productIdentifier: string;
-        purchaserInfo: PurchaserInfo;
+        customerInfo: CustomerInfo;
     }) => void, errorCallback: ({ error, userCancelled, }: {
         error: PurchasesError;
         userCancelled: boolean;
@@ -577,26 +577,26 @@ declare class Purchases {
      * Make a purchase
      *
      * @param {PurchasesPackage} aPackage The Package you wish to purchase. You can get the Packages by calling getOfferings
-     * @param {function(string, PurchaserInfo):void} callback Callback triggered after a successful purchase.
+     * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchase.
      * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error or when the user cancels the purchase.
      * If user cancelled, userCancelled will be true
      * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
      * and the optional prorationMode.
      */
-    static purchasePackage(aPackage: PurchasesPackage, callback: ({ productIdentifier, purchaserInfo, }: {
+    static purchasePackage(aPackage: PurchasesPackage, callback: ({ productIdentifier, customerInfo, }: {
         productIdentifier: string;
-        purchaserInfo: PurchaserInfo;
+        customerInfo: CustomerInfo;
     }) => void, errorCallback: ({ error, userCancelled, }: {
         error: PurchasesError;
         userCancelled: boolean;
     }) => void, upgradeInfo?: UpgradeInfo | null): void;
     /**
      * Restores a user's previous purchases and links their appUserIDs to any user's also using those purchases.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after restoring transactions.
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after restoring transactions.
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem restoring the user transactions. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user or the user cancelled the restore
      */
-    static restoreTransactions(callback: (purchaserInfo: PurchaserInfo) => void, errorCallback: (error: PurchasesError) => void): void;
+    static restorePurchases(callback: (customerInfo: CustomerInfo) => void, errorCallback: (error: PurchasesError) => void): void;
     /**
      * Get the appUserID that is currently in placed in the SDK
      * @param {function(string):void} callback Callback that will receive the current appUserID
@@ -606,7 +606,7 @@ declare class Purchases {
      * This function will logIn the current user with an appUserID. Typically this would be used after a log in
      * to identify a user without calling configure.
      * @param {String} appUserID The appUserID that should be linked to the currently user
-     * @param {function(LogInResult):void} callback Callback that will receive an object that contains the purchaserInfo after logging in, as well as a boolean indicating
+     * @param {function(LogInResult):void} callback Callback that will receive an object that contains the customerInfo after logging in, as well as a boolean indicating
      * whether the user has just been created for the first time in the RevenueCat backend.
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem logging in.
      */
@@ -614,44 +614,44 @@ declare class Purchases {
     /**
      * Logs out the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
      * If the current user is already anonymous, this will produce a PurchasesError.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after resetting
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after resetting
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is an error when logging out.
      * This could happen for example if logOut is called but the current user is anonymous.
      */
-    static logOut(callback: (purchaserInfo: PurchaserInfo) => void, errorCallback: (error: PurchasesError) => void): void;
+    static logOut(callback: (customerInfo: CustomerInfo) => void, errorCallback: (error: PurchasesError) => void): void;
     /**
      * @deprecated, use logIn instead.
      * This function will alias two appUserIDs together.
      * @param {string} newAppUserID The new appUserID that should be linked to the currently identified appUserID. Needs to be a string.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after creating the alias
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after creating the alias
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem creating the alias. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user or there is an error creating the alias.
      */
-    static createAlias(newAppUserID: string, callback: (purchaserInfo: PurchaserInfo) => void, errorCallback: (error: PurchasesError) => void): void;
+    static createAlias(newAppUserID: string, callback: (customerInfo: CustomerInfo) => void, errorCallback: (error: PurchasesError) => void): void;
     /**
      * @deprecated, use logIn instead.
      * This function will identify the current user with an appUserID. Typically this would be used after a logout to identify a new user without calling configure
      * @param {string} newAppUserID The appUserID that should be linked to the currently user
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after identifying.
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after identifying.
      * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem identifying the new user. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user.
      */
-    static identify(newAppUserID: string, callback: (purchaserInfo: PurchaserInfo) => void, errorCallback: (error: PurchasesError) => void): void;
+    static identify(newAppUserID: string, callback: (customerInfo: CustomerInfo) => void, errorCallback: (error: PurchasesError) => void): void;
     /**
      * @deprecated, use logOut instead.
      * Resets the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after resetting
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after resetting
      * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem resetting the SDK. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user.
      */
-    static reset(callback: (purchaserInfo: PurchaserInfo) => void, errorCallback: (error: PurchasesError) => void): void;
+    static reset(callback: (customerInfo: CustomerInfo) => void, errorCallback: (error: PurchasesError) => void): void;
     /**
-     * Gets the current purchaser info. This call will return the cached purchaser info unless the cache is stale, in which case,
+     * Gets the current customer info. This call will return the cached customer info unless the cache is stale, in which case,
      * it will make a network call to retrieve it from the servers.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the purchaser info
-     * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem retrieving the purchaser info
+     * @param {function(CustomerInfo):void} callback Callback that will receive the purchaser info
+     * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem retrieving the customer info
      */
-    static getPurchaserInfo(callback: (purchaserInfo: PurchaserInfo) => void, errorCallback: (error: PurchasesError) => void): void;
+    static getCustomerInfo(callback: (customerInfo: CustomerInfo) => void, errorCallback: (error: PurchasesError) => void): void;
     /**
      * Enables/Disables debugs logs
      * @param {boolean} enabled Enable or not debug logs
@@ -715,7 +715,7 @@ declare class Purchases {
      */
     static removeShouldPurchasePromoProductListener(listenerToRemove: ShouldPurchasePromoProductListener): boolean;
     /**
-     * Invalidates the cache for purchaser information.
+     * Invalidates the cache for customer information.
      *
      * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
      * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
@@ -724,7 +724,7 @@ declare class Purchases {
      * This is useful for cases where purchaser information might have been updated outside of the
      * app, like if a promotional subscription is granted through the RevenueCat dashboard.
      */
-    static invalidatePurchaserInfoCache(): void;
+    static invalidateCustomerInfoCache(): void;
     /**
      * iOS only. Presents a code redemption sheet, useful for redeeming offer codes
      * Refer to https://docs.revenuecat.com/docs/ios-subscription-offers#offer-codes for more information on how

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -450,7 +450,7 @@ var Purchases = /** @class */ (function () {
      * Invalidates the cache for customer information.
      *
      * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
-     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * Refer to https://docs.revenuecat.com/docs/customer-info#section-get-user-information for more information on
      * using the cache properly.
      *
      * This is useful for cases where purchaser information might have been updated outside of the

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -157,8 +157,8 @@ var Purchases = /** @class */ (function () {
      */
     Purchases.setup = function (apiKey, appUserID, observerMode, userDefaultsSuiteName) {
         if (observerMode === void 0) { observerMode = false; }
-        window.cordova.exec(function (purchaserInfo) {
-            window.cordova.fireWindowEvent("onPurchaserInfoUpdated", purchaserInfo);
+        window.cordova.exec(function (customerInfo) {
+            window.cordova.fireWindowEvent("onCustomerInfoUpdated", customerInfo);
         }, null, PLUGIN_NAME, "setupPurchases", [apiKey, appUserID, observerMode, userDefaultsSuiteName]);
         this.setupShouldPurchasePromoProductCallback();
     };
@@ -211,7 +211,7 @@ var Purchases = /** @class */ (function () {
      * Make a purchase
      *
      * @param {string} productIdentifier The product identifier of the product you want to purchase.
-     * @param {function(string, PurchaserInfo):void} callback Callback triggered after a successful purchase.
+     * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchase.
      * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error or when the user cancels the purchase.
      * If user cancelled, userCancelled will be true
      * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
@@ -239,7 +239,7 @@ var Purchases = /** @class */ (function () {
      * Make a purchase
      *
      * @param {PurchasesPackage} aPackage The Package you wish to purchase. You can get the Packages by calling getOfferings
-     * @param {function(string, PurchaserInfo):void} callback Callback triggered after a successful purchase.
+     * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchase.
      * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error or when the user cancels the purchase.
      * If user cancelled, userCancelled will be true
      * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
@@ -265,12 +265,12 @@ var Purchases = /** @class */ (function () {
     };
     /**
      * Restores a user's previous purchases and links their appUserIDs to any user's also using those purchases.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after restoring transactions.
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after restoring transactions.
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem restoring the user transactions. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user or the user cancelled the restore
      */
-    Purchases.restoreTransactions = function (callback, errorCallback) {
-        window.cordova.exec(callback, errorCallback, PLUGIN_NAME, "restoreTransactions", []);
+    Purchases.restorePurchases = function (callback, errorCallback) {
+        window.cordova.exec(callback, errorCallback, PLUGIN_NAME, "restorePurchases", []);
     };
     /**
      * Get the appUserID that is currently in placed in the SDK
@@ -283,7 +283,7 @@ var Purchases = /** @class */ (function () {
      * This function will logIn the current user with an appUserID. Typically this would be used after a log in
      * to identify a user without calling configure.
      * @param {String} appUserID The appUserID that should be linked to the currently user
-     * @param {function(LogInResult):void} callback Callback that will receive an object that contains the purchaserInfo after logging in, as well as a boolean indicating
+     * @param {function(LogInResult):void} callback Callback that will receive an object that contains the customerInfo after logging in, as well as a boolean indicating
      * whether the user has just been created for the first time in the RevenueCat backend.
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem logging in.
      */
@@ -299,7 +299,7 @@ var Purchases = /** @class */ (function () {
     /**
      * Logs out the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
      * If the current user is already anonymous, this will produce a PurchasesError.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after resetting
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after resetting
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is an error when logging out.
      * This could happen for example if logOut is called but the current user is anonymous.
      */
@@ -310,7 +310,7 @@ var Purchases = /** @class */ (function () {
      * @deprecated, use logIn instead.
      * This function will alias two appUserIDs together.
      * @param {string} newAppUserID The new appUserID that should be linked to the currently identified appUserID. Needs to be a string.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after creating the alias
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after creating the alias
      * @param {function(PurchasesError):void} errorCallback Callback that will be triggered whenever there is any problem creating the alias. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user or there is an error creating the alias.
      */
@@ -327,7 +327,7 @@ var Purchases = /** @class */ (function () {
      * @deprecated, use logIn instead.
      * This function will identify the current user with an appUserID. Typically this would be used after a logout to identify a new user without calling configure
      * @param {string} newAppUserID The appUserID that should be linked to the currently user
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after identifying.
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after identifying.
      * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem identifying the new user. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user.
      */
@@ -343,7 +343,7 @@ var Purchases = /** @class */ (function () {
     /**
      * @deprecated, use logOut instead.
      * Resets the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the new purchaser info after resetting
+     * @param {function(CustomerInfo):void} callback Callback that will receive the new purchaser info after resetting
      * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem resetting the SDK. This gets normally triggered if there
      * is an error retrieving the new purchaser info for the new user.
      */
@@ -351,13 +351,13 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(callback, errorCallback, PLUGIN_NAME, "reset", []);
     };
     /**
-     * Gets the current purchaser info. This call will return the cached purchaser info unless the cache is stale, in which case,
+     * Gets the current customer info. This call will return the cached customer info unless the cache is stale, in which case,
      * it will make a network call to retrieve it from the servers.
-     * @param {function(PurchaserInfo):void} callback Callback that will receive the purchaser info
-     * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem retrieving the purchaser info
+     * @param {function(CustomerInfo):void} callback Callback that will receive the purchaser info
+     * @param {function(PurchasesError, boolean):void} errorCallback Callback that will be triggered whenever there is any problem retrieving the customer info
      */
-    Purchases.getPurchaserInfo = function (callback, errorCallback) {
-        window.cordova.exec(callback, errorCallback, PLUGIN_NAME, "getPurchaserInfo", []);
+    Purchases.getCustomerInfo = function (callback, errorCallback) {
+        window.cordova.exec(callback, errorCallback, PLUGIN_NAME, "getCustomerInfo", []);
     };
     /**
      * Enables/Disables debugs logs
@@ -447,7 +447,7 @@ var Purchases = /** @class */ (function () {
         return false;
     };
     /**
-     * Invalidates the cache for purchaser information.
+     * Invalidates the cache for customer information.
      *
      * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
      * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
@@ -456,8 +456,8 @@ var Purchases = /** @class */ (function () {
      * This is useful for cases where purchaser information might have been updated outside of the
      * app, like if a promotional subscription is granted through the RevenueCat dashboard.
      */
-    Purchases.invalidatePurchaserInfoCache = function () {
-        window.cordova.exec(null, null, PLUGIN_NAME, "invalidatePurchaserInfoCache", []);
+    Purchases.invalidateCustomerInfoCache = function () {
+        window.cordova.exec(null, null, PLUGIN_NAME, "invalidateCustomerInfoCache", []);
     };
     /**
      * iOS only. Presents a code redemption sheet, useful for redeeming offer codes


### PR DESCRIPTION
`invalidatePurchaserInfoCache -> invalidateCustomerInfoCache`
`getPurchaserInfo -> getCustomerInfo`
Also update comments.
