### PR TITLE
Adds cordova-annotated-plugin-android dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "RevenueCat, Inc.",
   "license": "MIT",
   "dependencies": {
-    "cordova-annotated-plugin-android": "1.0.4"
+    "cordova-annotated-plugin-android": "^1.0.4"
   },
   "devDependencies": {
     "@types/jest": "^27.1.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   },
   "author": "RevenueCat, Inc.",
   "license": "MIT",
+  "dependencies": {
+    "cordova-annotated-plugin-android": "1.0.4"
+  },
   "devDependencies": {
     "@types/jest": "^27.1.5",
     "@types/node": "^12.6.8",


### PR DESCRIPTION
I was testing this https://github.com/RevenueCat/cordova-plugin-purchases/issues/112#issuecomment-1183431151 and realized that we don't have the dependency in the package.json so it doesn't get automatically installed when installing the plugin via npm.