### PR TITLE
Update Purchases.setup to Purchases.configure

### DIFF
--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -63,7 +63,7 @@ const app = {
     console.log("Received Event: " + id);
     console.log("---------");
     Purchases.setDebugLogsEnabled(true);
-    Purchases.setup("api_key");
+    Purchases.configure("api_key");
     Purchases.getCustomerInfo(
       info => {
         const isPro = typeof info.entitlements.active.pro_cat !== "undefined";

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -35,9 +35,9 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
     public static final String PLATFORM_NAME = "cordova";
     public static final String PLUGIN_VERSION = "3.0.0-rc.2";
 
-    @PluginAction(thread = ExecutionThread.UI, actionName = "setupPurchases", isAutofinish = false)
-    private void setupPurchases(String apiKey, @Nullable String appUserID, boolean observerMode,
-                                @Nullable String userDefaultsSuiteName, CallbackContext callbackContext) {
+    @PluginAction(thread = ExecutionThread.UI, actionName = "configure", isAutofinish = false)
+    private void configure(String apiKey, @Nullable String appUserID, boolean observerMode,
+                           @Nullable String userDefaultsSuiteName, CallbackContext callbackContext) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         CommonKt.configure(this.cordova.getActivity(), apiKey, appUserID, observerMode, platformInfo);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(new UpdatedCustomerInfoListener() {

--- a/src/ios/PurchasesPlugin.swift
+++ b/src/ios/PurchasesPlugin.swift
@@ -21,8 +21,8 @@ public class CDVPurchasesPlugin : CDVPlugin {
 
     private var purchases: Purchases!
 
-    @objc(setupPurchases:)
-    func setupPurchases(command: CDVInvokedUrlCommand) {
+    @objc(configure:)
+    func configure(command: CDVInvokedUrlCommand) {
         guard let apiKey = command.arguments[0] as? String else {
             self.sendBadParameterFor(command: command, parameterNamed: "apiKey", expectedType: String.self)
             return

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -627,7 +627,7 @@ class Purchases {
       },
       null,
       PLUGIN_NAME,
-      "setupPurchases",
+      "configure",
       [apiKey, appUserID, observerMode, userDefaultsSuiteName]
     );
     this.setupShouldPurchasePromoProductCallback();

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -615,7 +615,7 @@ class Purchases {
    * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults 
    * suite, otherwise it will use standardUserDefaults. Default is null, which will make the SDK use standardUserDefaults.
    */
-  public static setup(
+  public static configure(
     apiKey: string,
     appUserID?: string | null,
     observerMode: boolean = false,

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -7,40 +7,40 @@ window.cordova = {
 };
 
 describe("Purchases", () => {
-  it("setup fires PurchasesPlugin with the correct arguments", () => {
-    Purchases.setup("api_key", "app_user_id");
+  it("configure fires PurchasesPlugin with the correct arguments", () => {
+    Purchases.configure("api_key", "app_user_id");
 
     expect(execFn).toHaveBeenCalledWith(
       expect.any(Function),
       null,
       "PurchasesPlugin",
-      "setupPurchases",
+      "configure",
       ["api_key", "app_user_id", false, undefined]
     );
   });
 
-  it("setup fires PurchasesPlugin with the correct arguments when specifying observermode", () => {
-    Purchases.setup("api_key", "app_user_id", true);
+  it("configure fires PurchasesPlugin with the correct arguments when specifying observermode", () => {
+    Purchases.configure("api_key", "app_user_id", true);
 
     expect(execFn).toHaveBeenCalledWith(
       expect.any(Function),
       null,
       "PurchasesPlugin",
-      "setupPurchases",
+      "configure",
       ["api_key", "app_user_id", true, undefined]
     );
   });
 
-  it("setup fires PurchasesPlugin with the correct arguments when setting user defaults suite name", () => {
+  it("configure fires PurchasesPlugin with the correct arguments when setting user defaults suite name", () => {
     const expected = "suite-name";
 
-    Purchases.setup("api_key", "app_user_id", false, expected);
+    Purchases.configure("api_key", "app_user_id", false, expected);
 
     expect(execFn).toHaveBeenCalledWith(
       expect.any(Function),
       null,
       "PurchasesPlugin",
-      "setupPurchases",
+      "configure",
       ["api_key", "app_user_id", false, expected]
     );
   });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,7 +1,7 @@
 exports.defineAutoTests = function() {
   describe("Purchases (Purchases)", function() {
     beforeAll(function() {
-      Purchases.setup("api_key");
+      Purchases.configure("api_key");
     });
 
     it("should exist", function() {

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -578,7 +578,7 @@ declare class Purchases {
      * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults
      * suite, otherwise it will use standardUserDefaults. Default is null, which will make the SDK use standardUserDefaults.
      */
-    static setup(apiKey: string, appUserID?: string | null, observerMode?: boolean, userDefaultsSuiteName?: string): void;
+    static configure(apiKey: string, appUserID?: string | null, observerMode?: boolean, userDefaultsSuiteName?: string): void;
     /**
      * Gets the Offerings configured in the RevenueCat dashboard
      * @param {function(PurchasesOfferings):void} callback Callback triggered after a successful getOfferings call.

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -163,7 +163,7 @@ var Purchases = /** @class */ (function () {
         if (observerMode === void 0) { observerMode = false; }
         window.cordova.exec(function (customerInfo) {
             window.cordova.fireWindowEvent("onCustomerInfoUpdated", customerInfo);
-        }, null, PLUGIN_NAME, "setupPurchases", [apiKey, appUserID, observerMode, userDefaultsSuiteName]);
+        }, null, PLUGIN_NAME, "configure", [apiKey, appUserID, observerMode, userDefaultsSuiteName]);
         this.setupShouldPurchasePromoProductCallback();
     };
     /**

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -159,7 +159,7 @@ var Purchases = /** @class */ (function () {
      * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults
      * suite, otherwise it will use standardUserDefaults. Default is null, which will make the SDK use standardUserDefaults.
      */
-    Purchases.setup = function (apiKey, appUserID, observerMode, userDefaultsSuiteName) {
+    Purchases.configure = function (apiKey, appUserID, observerMode, userDefaultsSuiteName) {
         if (observerMode === void 0) { observerMode = false; }
         window.cordova.exec(function (customerInfo) {
             window.cordova.fireWindowEvent("onCustomerInfoUpdated", customerInfo);


### PR DESCRIPTION
Brings our API back to the same naming as our current native releases.

Resolves [CSDK-187]

[CSDK-187]: https://revenuecats.atlassian.net/browse/CSDK-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ