### PR TITLE
Preparing for version 3.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Bump`purchases-hybrid-common` to `4.0.0` 
     [4.0.0 Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/4.0.0)
+- Bump `purchases-ios` to `4.9.1` 
+    [4.9.2 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/4.9.1)
 
 ## 3.0.0-rc.3
 ### Updating plugin for the most recent RevenueCat frameworks released!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Bump`purchases-hybrid-common` to `4.0.0` 
     [4.0.0 Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/4.0.0)
 - Bump `purchases-ios` to `4.9.1` 
-    [4.9.2 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/4.9.1)
+    [4.9.1 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/4.9.1)
 
 ## 3.0.0-rc.3
 ### Updating plugin for the most recent RevenueCat frameworks released!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-purchases",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "Purchases Cordova Plugin",
   "types": "./www/plugin.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-purchases" version="3.0.0-rc.3">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-purchases" version="3.0.0-rc.4">
 
     <dependency id="cordova-annotated-plugin-android" />
 

--- a/scripts/docs/index.html
+++ b/scripts/docs/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/cordova-plugin-purchases-docs/3.0.0-rc.3/" />
+	<meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/cordova-plugin-purchases-docs/3.0.0-rc.4/" />
 </head>
 <body>
 </body>

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class PurchasesPlugin extends AnnotatedCordovaPlugin {
 
     public static final String PLATFORM_NAME = "cordova";
-    public static final String PLUGIN_VERSION = "3.0.0-rc.3";
+    public static final String PLUGIN_VERSION = "3.0.0-rc.4";
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "configure", isAutofinish = false)
     private void configure(String apiKey, @Nullable String appUserID, boolean observerMode,

--- a/src/ios/PurchasesPlugin.swift
+++ b/src/ios/PurchasesPlugin.swift
@@ -71,7 +71,7 @@ extension CDVPurchasesPlugin {
     }
 
     var platformFlavorVersion: String {
-        return "3.0.0-rc.3"
+        return "3.0.0-rc.4"
     }
 
 }


### PR DESCRIPTION
## 3.0.0-rc.4
### Updating plugin for the most recent RevenueCat frameworks released!
#### StoreKit 2 support

### Property rename:
#### PurchasesStoreProduct
- Updated `readonly intro_price: PurchasesIntroPrice | null;` to `readonly introPrice: PurchasesIntroPrice | null;`
- Updated `readonly price_string: string;` to `readonly priceString: string;`
- Updated `readonly currency_code: string;` to `readonly currencyCode: string;`

*See previous 3.0.0-rc.x notes for a complete log.*

- Bump`purchases-hybrid-common` to `4.0.0` 
    [4.0.0 Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/4.0.0)
- Bump `purchases-ios` to `4.9.1` 
    [4.9.1 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/4.9.1)
