### PR TITLE
Update Hybrid Common 4.1.0 and add AdServices

### DIFF
--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -64,6 +64,7 @@ const app = {
     console.log("---------");
     Purchases.setDebugLogsEnabled(true);
     Purchases.configure("api_key");
+    Purchases.enableAdServicesAttributionTokenCollection();
     Purchases.getCustomerInfo(
       info => {
         const isPro = typeof info.entitlements.active.pro_cat !== "undefined";

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
                 <param name="android-package" value="com.revenuecat.purchases.PurchasesPlugin" />
             </feature>
         </config-file>
-        <framework src="com.revenuecat.purchases:purchases-hybrid-common:4.0.0" />
+        <framework src="com.revenuecat.purchases:purchases-hybrid-common:4.1.0" />
         <framework src="androidx.annotation:annotation:[1.4.0]"/>
         <source-file src="src/android/PurchasesPlugin.java" target-dir="src/com/revenuecat/purchases"/>
     </platform>
@@ -38,7 +38,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="PurchasesHybridCommon" spec="4.0.0"/>
+                <pod name="PurchasesHybridCommon" spec="4.1.0"/>
             </pods>
         </podspec>
     </platform>

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -161,6 +161,11 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         // NOOP
     }
 
+    @PluginAction(thread = ExecutionThread.WORKER, actionName = "enableAdServicesAttributionTokenCollection")
+    private void enableAdServicesAttributionTokenCollection(CallbackContext callbackContext) {
+        // NOOP
+    }
+
     @PluginAction(thread = ExecutionThread.WORKER, actionName = "setupShouldPurchasePromoProductCallback")
     private void setupShouldPurchasePromoProductCallback(CallbackContext callbackContext) {
         // NOOP

--- a/src/ios/PurchasesPlugin+Attribution.swift
+++ b/src/ios/PurchasesPlugin+Attribution.swift
@@ -23,6 +23,16 @@ import PurchasesHybridCommon
         self.sendOKFor(command: command)
     }
 
+    @objc(enableAdServicesAttributionTokenCollection:)
+    func enableAdServicesAttributionTokenCollection(command: CDVInvokedUrlCommand) {
+        if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+            CommonFunctionality.enableAdServicesAttributionTokenCollection()
+        } else {
+            NSLog("[Purchases] Warning: tried to enable AdServices attribution token collection, but it's only available on iOS 14.3 or greater or macOS 11.1 or greater.");
+        }
+        self.sendOKFor(command: command)
+    }
+
     @objc(setAttributes:)
     func setAttributes(command: CDVInvokedUrlCommand) {
         guard let attributes = command.arguments[0] as? [String: String] else {

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -882,8 +882,6 @@ class Purchases {
 
   /**
    * Enable automatic collection of Apple Search Ads attribution using AdServices. Disabled by default.
-   *
-   * @param {boolean} enabled Enable or not automatic collection
    */
      public static enableAdServicesAttributionTokenCollection(): void {
       window.cordova.exec(

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -881,6 +881,21 @@ class Purchases {
   }
 
   /**
+   * Enable automatic collection of Apple Search Ads attribution using AdServices. Disabled by default.
+   *
+   * @param {boolean} enabled Enable or not automatic collection
+   */
+     public static enableAdServicesAttributionTokenCollection(): void {
+      window.cordova.exec(
+        null,
+        null,
+        PLUGIN_NAME,
+        "enableAdServicesAttributionTokenCollection",
+        []
+      );
+    }
+
+  /**
    * @param {function(boolean):void} callback Will be sent a boolean indicating if the `appUserID` has been generated
    * by RevenueCat or not.
    */

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -689,6 +689,12 @@ declare class Purchases {
      */
     static setAutomaticAppleSearchAdsAttributionCollection(enabled: boolean): void;
     /**
+     * Enable automatic collection of Apple Search Ads attribution using AdServices. Disabled by default.
+     *
+     * @param {boolean} enabled Enable or not automatic collection
+     */
+    static enableAdServicesAttributionTokenCollection(): void;
+    /**
      * @param {function(boolean):void} callback Will be sent a boolean indicating if the `appUserID` has been generated
      * by RevenueCat or not.
      */

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -690,8 +690,6 @@ declare class Purchases {
     static setAutomaticAppleSearchAdsAttributionCollection(enabled: boolean): void;
     /**
      * Enable automatic collection of Apple Search Ads attribution using AdServices. Disabled by default.
-     *
-     * @param {boolean} enabled Enable or not automatic collection
      */
     static enableAdServicesAttributionTokenCollection(): void;
     /**

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -331,8 +331,6 @@ var Purchases = /** @class */ (function () {
     };
     /**
      * Enable automatic collection of Apple Search Ads attribution using AdServices. Disabled by default.
-     *
-     * @param {boolean} enabled Enable or not automatic collection
      */
     Purchases.enableAdServicesAttributionTokenCollection = function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "enableAdServicesAttributionTokenCollection", []);

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -330,6 +330,14 @@ var Purchases = /** @class */ (function () {
         window.cordova.exec(null, null, PLUGIN_NAME, "setAutomaticAppleSearchAdsAttributionCollection", [enabled]);
     };
     /**
+     * Enable automatic collection of Apple Search Ads attribution using AdServices. Disabled by default.
+     *
+     * @param {boolean} enabled Enable or not automatic collection
+     */
+    Purchases.enableAdServicesAttributionTokenCollection = function () {
+        window.cordova.exec(null, null, PLUGIN_NAME, "enableAdServicesAttributionTokenCollection", []);
+    };
+    /**
      * @param {function(boolean):void} callback Will be sent a boolean indicating if the `appUserID` has been generated
      * by RevenueCat or not.
      */


### PR DESCRIPTION
- Updated Hybrid Common to `4.1.0`
- Adds new `enableAdServicesAttributionTokenCollection` method
  - No-op on non-iOS platforms
