### PR TITLE
Preparing for version 3.0.0-rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 *See previous 3.0.0-rc.x notes for a complete log.*
 
 - Bump`purchases-hybrid-common` to `4.2.0` 
-    [4.1.4 Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/4.1.4)
+    [4.2.0 Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/4.2.0)
 - Bump `purchases-android` to `5.6.0` 
     [5.6.0 Changelog here](https://github.com/RevenueCat/purchases-android/releases/5.6.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-purchases",
-  "version": "3.0.0-rc.7",
+  "version": "3.0.0-rc.8",
   "description": "Purchases Cordova Plugin",
   "types": "./www/plugin.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-purchases" version="3.0.0-rc.7">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-purchases" version="3.0.0-rc.8">
 
     <dependency id="cordova-annotated-plugin-android" />
 

--- a/scripts/docs/index.html
+++ b/scripts/docs/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/cordova-plugin-purchases-docs/3.0.0-rc.7/" />
+	<meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/cordova-plugin-purchases-docs/3.0.0-rc.8/" />
 </head>
 <body>
 </body>

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class PurchasesPlugin extends AnnotatedCordovaPlugin {
 
     public static final String PLATFORM_NAME = "cordova";
-    public static final String PLUGIN_VERSION = "3.0.0-rc.7";
+    public static final String PLUGIN_VERSION = "3.0.0-rc.8";
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "configure", isAutofinish = false)
     private void configure(String apiKey, @Nullable String appUserID, boolean observerMode,

--- a/src/ios/PurchasesPlugin.swift
+++ b/src/ios/PurchasesPlugin.swift
@@ -71,7 +71,7 @@ extension CDVPurchasesPlugin {
     }
 
     var platformFlavorVersion: String {
-        return "3.0.0-rc.7"
+        return "3.0.0-rc.8"
     }
 
 }


### PR DESCRIPTION
## 3.0.0-rc.8

- Added attribution methods for CleverTap, Mixpanel, and Firebase.
      `Purchases.setCleverTapID`, `Purchases.setMixpanelDistinctID`, and `Purchases.setFirebaseAppInstanceID`

*See previous 3.0.0-rc.x notes for a complete log.*

- Bump`purchases-hybrid-common` to `4.2.0`
    [4.2.0 Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/4.2.0)
- Bump `purchases-android` to `5.6.0`
    [5.6.0 Changelog here](https://github.com/RevenueCat/purchases-android/releases/5.6.0)
