### PR TITLE
fix: race conditions in example app

### DIFF
--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -25,8 +25,48 @@ const app = {
       this.onDeviceReady.bind(this),
       false
     );
+    // this method gets called after configure is done
     window.addEventListener("onCustomerInfoUpdated", (info) => {
+      
+      this.setupShouldPurchasePromoProductListener();
 
+      Purchases.enableAdServicesAttributionTokenCollection();
+      Purchases.getCustomerInfo(
+        info => {
+          const isPro = typeof info.entitlements.active.pro_cat !== "undefined";
+          console.log("isPro " + JSON.stringify(isPro));
+          console.log(JSON.stringify(info));
+        },
+        error => {
+          debugger;
+          console.log(JSON.stringify(error));
+        }
+      );
+  
+      Purchases.isAnonymous(
+        isAnonymous => {
+          console.log("ISANONYMOUS " + isAnonymous);
+          }
+      );
+  
+      Purchases.getOfferings(
+        offerings => {
+          Purchases.checkTrialOrIntroductoryPriceEligibility([offerings.current.lifetime.product.identifier, "some_offering"],
+            map => {
+              console.log(map)
+            }
+          );
+          console.log(JSON.stringify(offerings));
+        },
+        ( error ) => {
+          console.log(JSON.stringify(error));
+        }
+      );
+
+      Purchases.setPhoneNumber("12345678");
+      Purchases.setDisplayName("Garfield");
+      Purchases.setAttributes({ "favorite_cat": "garfield" });
+      Purchases.setEmail("garfield@revenuecat.com");
     });
   },
 
@@ -36,11 +76,6 @@ const app = {
   // 'pause', 'resume', etc.
   onDeviceReady: function() {
     this.receivedEvent("deviceready");
-    this.setupShouldPurchasePromoProductListener();
-    Purchases.setPhoneNumber("12345678");
-    Purchases.setDisplayName("Garfield");
-    Purchases.setAttributes({ "favorite_cat": "garfield" });
-    Purchases.setEmail("garfield@revenuecat.com");
   },
 
   setupShouldPurchasePromoProductListener: function() {
@@ -64,38 +99,6 @@ const app = {
     console.log("---------");
     Purchases.setDebugLogsEnabled(true);
     Purchases.configure("api_key");
-    Purchases.enableAdServicesAttributionTokenCollection();
-    Purchases.getCustomerInfo(
-      info => {
-        const isPro = typeof info.entitlements.active.pro_cat !== "undefined";
-        console.log("isPro " + JSON.stringify(isPro));
-        console.log(JSON.stringify(info));
-      },
-      error => {
-        debugger;
-        console.log(JSON.stringify(error));
-      }
-    );
-
-    Purchases.isAnonymous(
-      isAnonymous => {
-        console.log("ISANONYMOUS " + isAnonymous);
-        }
-    );
-
-    Purchases.getOfferings(
-      offerings => {
-        Purchases.checkTrialOrIntroductoryPriceEligibility([offerings.current.lifetime.product.identifier, "some_offering"],
-          map => {
-            console.log(map)
-          }
-        );
-        console.log(JSON.stringify(offerings));
-      },
-      ( error ) => {
-        console.log(JSON.stringify(error));
-      }
-    );
   }
 };
 

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -18,6 +18,7 @@
  */
 
 const app = {
+  isInitialized: false,
   // Application Constructor
   initialize: function() {
     document.addEventListener(
@@ -26,8 +27,11 @@ const app = {
       false
     );
     // this method gets called after configure is done
+    // or when the customerInfo is updated from a purchase, restore, login / out or renewal
     window.addEventListener("onCustomerInfoUpdated", (info) => {
-      
+      if (this.isInitialized) { return; }
+      this.isInitialized = true;
+
       this.setupShouldPurchasePromoProductListener();
 
       Purchases.enableAdServicesAttributionTokenCollection();


### PR DESCRIPTION
This fixes race conditions in the example app.

The issue is that the app assumes that configure isn't async, but it actually is (the signature is broken 🤦)

`configure` does actually output an event when it's done, so the quick fix is to just subscribe to that event. 

The real fix would be to fix the configure method, but that's a separate PR. 

This is the kind of error we were getting before, when calling a method right after calling configure:

<img width="1374" alt="Screen Shot 2022-09-02 at 5 30 53 PM" src="https://user-images.githubusercontent.com/3922667/188231627-95ad03a9-793e-4e0b-9502-c8f786076b5b.png">


