### PR TITLE
Add callback when `configure` is finished

### DIFF
--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -65,11 +65,13 @@ function checkConfigure() {
 
   Purchases.configure(
     apiKey,
+    () => {},
     appUserID,
     observerMode
   );
   Purchases.configure(
     apiKey,
+    () => {},
     appUserID,
     observerMode,
     userDefaultsSuiteName

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -18,7 +18,6 @@
  */
 
 const app = {
-  isInitialized: false,
   // Application Constructor
   initialize: function() {
     document.addEventListener(
@@ -26,52 +25,6 @@ const app = {
       this.onDeviceReady.bind(this),
       false
     );
-    // this method gets called after configure is done
-    // or when the customerInfo is updated from a purchase, restore, login / out or renewal
-    window.addEventListener("onCustomerInfoUpdated", (info) => {
-      if (this.isInitialized) { return; }
-      this.isInitialized = true;
-
-      this.setupShouldPurchasePromoProductListener();
-
-      Purchases.enableAdServicesAttributionTokenCollection();
-      Purchases.getCustomerInfo(
-        info => {
-          const isPro = typeof info.entitlements.active.pro_cat !== "undefined";
-          console.log("isPro " + JSON.stringify(isPro));
-          console.log(JSON.stringify(info));
-        },
-        error => {
-          debugger;
-          console.log(JSON.stringify(error));
-        }
-      );
-  
-      Purchases.isAnonymous(
-        isAnonymous => {
-          console.log("ISANONYMOUS " + isAnonymous);
-          }
-      );
-  
-      Purchases.getOfferings(
-        offerings => {
-          Purchases.checkTrialOrIntroductoryPriceEligibility([offerings.current.lifetime.product.identifier, "some_offering"],
-            map => {
-              console.log(map)
-            }
-          );
-          console.log(JSON.stringify(offerings));
-        },
-        ( error ) => {
-          console.log(JSON.stringify(error));
-        }
-      );
-
-      Purchases.setPhoneNumber("12345678");
-      Purchases.setDisplayName("Garfield");
-      Purchases.setAttributes({ "favorite_cat": "garfield" });
-      Purchases.setEmail("garfield@revenuecat.com");
-    });
   },
 
   // deviceready Event Handler
@@ -82,13 +35,6 @@ const app = {
     this.receivedEvent("deviceready");
   },
 
-  setupShouldPurchasePromoProductListener: function() {
-    Purchases.addShouldPurchasePromoProductListener((makeDeferredPurchase) => {
-      console.log("This codes executes right before making the purchase");
-      makeDeferredPurchase();
-      console.log("This codes executes right after making the purchase");
-    });
-  },
 
   // Update DOM on a Received Event
   receivedEvent: function(id) {
@@ -102,8 +48,64 @@ const app = {
     console.log("Received Event: " + id);
     console.log("---------");
     Purchases.setDebugLogsEnabled(true);
-    Purchases.configure("api_key");
-  }
+    Purchases.configure("api_key", function() { 
+      console.log("Configured");
+      initializePurchasesSDK();
+    });
+  },
+
 };
 
+initializePurchasesSDK = function() {
+
+  this.setupShouldPurchasePromoProductListener();
+
+  Purchases.enableAdServicesAttributionTokenCollection();
+  Purchases.getCustomerInfo(
+    info => {
+      const isPro = typeof info.entitlements.active.pro_cat !== "undefined";
+      console.log("isPro " + JSON.stringify(isPro));
+      console.log(JSON.stringify(info));
+    },
+    error => {
+      debugger;
+      console.log(JSON.stringify(error));
+    }
+  );
+
+  Purchases.isAnonymous(
+    isAnonymous => {
+      console.log("ISANONYMOUS " + isAnonymous);
+      }
+  );
+
+  Purchases.getOfferings(
+    offerings => {
+      Purchases.checkTrialOrIntroductoryPriceEligibility([offerings.current.lifetime.product.identifier, "some_offering"],
+        map => {
+          console.log(map)
+        }
+      );
+      console.log(JSON.stringify(offerings));
+    },
+    ( error ) => {
+      console.log(JSON.stringify(error));
+    }
+  );
+
+  Purchases.setPhoneNumber("12345678");
+  Purchases.setDisplayName("Garfield");
+  Purchases.setAttributes({ "favorite_cat": "garfield" });
+  Purchases.setEmail("garfield@revenuecat.com");
+}
+
+setupShouldPurchasePromoProductListener = function() {
+  Purchases.addShouldPurchasePromoProductListener((makeDeferredPurchase) => {
+    console.log("This codes executes right before making the purchase");
+    makeDeferredPurchase();
+    console.log("This codes executes right after making the purchase");
+  });
+},
+
 app.initialize();
+

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -617,13 +617,15 @@ class Purchases {
    */
   public static configure(
     apiKey: string,
+    callback: () => void,
     appUserID?: string | null,
     observerMode: boolean = false,
-    userDefaultsSuiteName?: string
+    userDefaultsSuiteName?: string,
   ): void {
     window.cordova.exec(
       (customerInfo: any) => {
         window.cordova.fireWindowEvent("onCustomerInfoUpdated", customerInfo);
+        callback();
       },
       null,
       PLUGIN_NAME,

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -8,41 +8,42 @@ window.cordova = {
 
 describe("Purchases", () => {
   it("configure fires PurchasesPlugin with the correct arguments", () => {
-    Purchases.configure("api_key", "app_user_id");
-
-    expect(execFn).toHaveBeenCalledWith(
-      expect.any(Function),
-      null,
-      "PurchasesPlugin",
-      "configure",
-      ["api_key", "app_user_id", false, undefined]
-    );
+    Purchases.configure("api_key", () => {
+      expect(execFn).toHaveBeenCalledWith(
+        expect.any(Function),
+        null,
+        "PurchasesPlugin",
+        "configure",
+        ["api_key", "app_user_id", false, undefined]
+      );
+    },
+     "app_user_id");
   });
 
   it("configure fires PurchasesPlugin with the correct arguments when specifying observermode", () => {
-    Purchases.configure("api_key", "app_user_id", true);
-
-    expect(execFn).toHaveBeenCalledWith(
-      expect.any(Function),
-      null,
-      "PurchasesPlugin",
-      "configure",
-      ["api_key", "app_user_id", true, undefined]
-    );
+    Purchases.configure("api_key", () => {
+      expect(execFn).toHaveBeenCalledWith(
+        expect.any(Function),
+        null,
+        "PurchasesPlugin",
+        "configure",
+        ["api_key", "app_user_id", true, undefined]
+      );
+    }, "app_user_id", true);
   });
 
   it("configure fires PurchasesPlugin with the correct arguments when setting user defaults suite name", () => {
     const expected = "suite-name";
 
-    Purchases.configure("api_key", "app_user_id", false, expected);
-
-    expect(execFn).toHaveBeenCalledWith(
-      expect.any(Function),
-      null,
-      "PurchasesPlugin",
-      "configure",
-      ["api_key", "app_user_id", false, expected]
-    );
+    Purchases.configure("api_key", () => {
+      expect(execFn).toHaveBeenCalledWith(
+        expect.any(Function),
+        null,
+        "PurchasesPlugin",
+        "configure",
+        ["api_key", "app_user_id", false, expected]
+      );
+    }, "app_user_id", false, expected);
   });
 
   it("setProxyURL fires PurchasesPlugin with the correct arguments", () => {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,7 +1,7 @@
 exports.defineAutoTests = function() {
   describe("Purchases (Purchases)", function() {
     beforeAll(function() {
-      Purchases.configure("api_key");
+      Purchases.configure("api_key", () => {});
     });
 
     it("should exist", function() {

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -578,7 +578,7 @@ declare class Purchases {
      * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults
      * suite, otherwise it will use standardUserDefaults. Default is null, which will make the SDK use standardUserDefaults.
      */
-    static configure(apiKey: string, appUserID?: string | null, observerMode?: boolean, userDefaultsSuiteName?: string): void;
+    static configure(apiKey: string, callback: () => void, appUserID?: string | null, observerMode?: boolean, userDefaultsSuiteName?: string): void;
     /**
      * Gets the Offerings configured in the RevenueCat dashboard
      * @param {function(PurchasesOfferings):void} callback Callback triggered after a successful getOfferings call.

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -159,10 +159,11 @@ var Purchases = /** @class */ (function () {
      * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults
      * suite, otherwise it will use standardUserDefaults. Default is null, which will make the SDK use standardUserDefaults.
      */
-    Purchases.configure = function (apiKey, appUserID, observerMode, userDefaultsSuiteName) {
+    Purchases.configure = function (apiKey, callback, appUserID, observerMode, userDefaultsSuiteName) {
         if (observerMode === void 0) { observerMode = false; }
         window.cordova.exec(function (customerInfo) {
             window.cordova.fireWindowEvent("onCustomerInfoUpdated", customerInfo);
+            callback();
         }, null, PLUGIN_NAME, "configure", [apiKey, appUserID, observerMode, userDefaultsSuiteName]);
         this.setupShouldPurchasePromoProductCallback();
     };


### PR DESCRIPTION
Because of the asynchronous nature of Cordova's interaction with native methods, there's technically no way to have a synchronous `configure` method. 

However, our `configure` method is currently set up as synchronous, which is a problem, because if you call other methods right after it, you'll get errors (see #183)

This PR solves it by adding a required callback for `configure`. 