### PR TITLE
Fix prepare_next_version job in CircleCI machines

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   danger


### PR DESCRIPTION
After the automation in #182, it should have created a PR bumping the version to the next snapshot version but it failed: https://app.circleci.com/pipelines/github/RevenueCat/cordova-plugin-purchases/785/workflows/b7c08242-c961-4b06-bd61-81a75c68e1a6/jobs/1377 . Looks like in CircleCI machines, we are adding the `x86_64-linux` platform for some reason... which is causing git to be dirty and so it fails on the job. This PR just adds that platform to the lock file, done using: `bundle lock --add-platform x86_64-linux`.
