### PR TITLE
Configure should be called in the current thread and not in a UI thread

### DIFF
--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -18,7 +18,6 @@
  */
 
 const app = {
-  isInitialized: false,
   // Application Constructor
   initialize: function() {
     document.addEventListener(
@@ -26,51 +25,8 @@ const app = {
       this.onDeviceReady.bind(this),
       false
     );
-    // this method gets called after configure is done
-    // or when the customerInfo is updated from a purchase, restore, login / out or renewal
     window.addEventListener("onCustomerInfoUpdated", (info) => {
-      if (this.isInitialized) { return; }
-      this.isInitialized = true;
 
-      this.setupShouldPurchasePromoProductListener();
-
-      Purchases.enableAdServicesAttributionTokenCollection();
-      Purchases.getCustomerInfo(
-        info => {
-          const isPro = typeof info.entitlements.active.pro_cat !== "undefined";
-          console.log("isPro " + JSON.stringify(isPro));
-          console.log(JSON.stringify(info));
-        },
-        error => {
-          debugger;
-          console.log(JSON.stringify(error));
-        }
-      );
-  
-      Purchases.isAnonymous(
-        isAnonymous => {
-          console.log("ISANONYMOUS " + isAnonymous);
-          }
-      );
-  
-      Purchases.getOfferings(
-        offerings => {
-          Purchases.checkTrialOrIntroductoryPriceEligibility([offerings.current.lifetime.product.identifier, "some_offering"],
-            map => {
-              console.log(map)
-            }
-          );
-          console.log(JSON.stringify(offerings));
-        },
-        ( error ) => {
-          console.log(JSON.stringify(error));
-        }
-      );
-
-      Purchases.setPhoneNumber("12345678");
-      Purchases.setDisplayName("Garfield");
-      Purchases.setAttributes({ "favorite_cat": "garfield" });
-      Purchases.setEmail("garfield@revenuecat.com");
     });
   },
 
@@ -80,6 +36,11 @@ const app = {
   // 'pause', 'resume', etc.
   onDeviceReady: function() {
     this.receivedEvent("deviceready");
+    this.setupShouldPurchasePromoProductListener();
+    Purchases.setPhoneNumber("12345678");
+    Purchases.setDisplayName("Garfield");
+    Purchases.setAttributes({ "favorite_cat": "garfield" });
+    Purchases.setEmail("garfield@revenuecat.com");
   },
 
   setupShouldPurchasePromoProductListener: function() {
@@ -103,6 +64,38 @@ const app = {
     console.log("---------");
     Purchases.setDebugLogsEnabled(true);
     Purchases.configure("api_key");
+    Purchases.enableAdServicesAttributionTokenCollection();
+    Purchases.getCustomerInfo(
+      info => {
+        const isPro = typeof info.entitlements.active.pro_cat !== "undefined";
+        console.log("isPro " + JSON.stringify(isPro));
+        console.log(JSON.stringify(info));
+      },
+      error => {
+        debugger;
+        console.log(JSON.stringify(error));
+      }
+    );
+
+    Purchases.isAnonymous(
+      isAnonymous => {
+        console.log("ISANONYMOUS " + isAnonymous);
+        }
+    );
+
+    Purchases.getOfferings(
+      offerings => {
+        Purchases.checkTrialOrIntroductoryPriceEligibility([offerings.current.lifetime.product.identifier, "some_offering"],
+          map => {
+            console.log(map)
+          }
+        );
+        console.log(JSON.stringify(offerings));
+      },
+      ( error ) => {
+        console.log(JSON.stringify(error));
+      }
+    );
   }
 };
 

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -35,6 +35,10 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
     public static final String PLATFORM_NAME = "cordova";
     public static final String PLUGIN_VERSION = "3.0.0-rc.8";
 
+    // Needs to run on ExecutionThread.MAIN so it blocks the JavaBridge thread created by Cordova
+    // That way we guarantee any other call to the plugin happen after configure has completed
+    // Otherwise, the configure plugin call will complete before configure finishes, and
+    // other calls to the plugin will fail with UninitializedPropertyAccessException
     @PluginAction(thread = ExecutionThread.MAIN, actionName = "configure", isAutofinish = false)
     private void configure(String apiKey, @Nullable String appUserID, boolean observerMode,
                            @Nullable String userDefaultsSuiteName, CallbackContext callbackContext) {

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -177,7 +177,7 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
     }
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "checkTrialOrIntroductoryPriceEligibility", isAutofinish = false)
-    private void isAnonymous(JSONArray productIDs, CallbackContext callbackContext) {
+    private void checkTrialOrIntroductoryPriceEligibility(JSONArray productIDs, CallbackContext callbackContext) {
         List<String> productIDList = new ArrayList<>();
         for (int i = 0; i < productIDs.length(); i++) {
             try {

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -35,7 +35,7 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
     public static final String PLATFORM_NAME = "cordova";
     public static final String PLUGIN_VERSION = "3.0.0-rc.8";
 
-    @PluginAction(thread = ExecutionThread.UI, actionName = "configure", isAutofinish = false)
+    @PluginAction(thread = ExecutionThread.MAIN, actionName = "configure", isAutofinish = false)
     private void configure(String apiKey, @Nullable String appUserID, boolean observerMode,
                            @Nullable String userDefaultsSuiteName, CallbackContext callbackContext) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);


### PR DESCRIPTION
We were calling configure in the UI thread (main)

This is the thread where Cordova Java code runs. Note is in the `main` pool but it's not the main thread. 

<img width="501" alt="Screen Shot 2022-09-29 at 5 00 26 PM" src="https://user-images.githubusercontent.com/664544/193072662-4cfdd2bf-a1e7-43b0-ab8a-d2c23d102aac.png">

We had `ExecutionThread.UI` as the thread configure should be running on. So this code in the annotation plugin was running on that JavaBridge thread:

```
Object[] mArgs = getMethodArgs(args, callbackContext);
Runnable runnable = this.createRunnable(mArgs, caller, callbackContext);
if (executionThread == ExecutionThread.WORKER) {
  cordova.getThreadPool().execute(runnable);
} else if (executionThread == ExecutionThread.UI) {
  cordova.getActivity().runOnUiThread(runnable);
} else {
  runnable.run();
}
```

And calling `configure` in our plugin in the `main` thread in the `main` pool. Setting a breakpoint inside `configure` in phc shows this thread:

<img width="1000" alt="Screen Shot 2022-09-29 at 5 26 56 PM" src="https://user-images.githubusercontent.com/664544/193073584-89445596-c3b1-44fc-918a-8240778ae78d.png">

This means making these Javascript calls:

```
    Purchases.configure("api_key");
    Purchases.isAnonymous(
      isAnonymous => {
        console.log("ISANONYMOUS " + isAnonymous);
        }
    );
```

Would trigger the following exception:

```
Uncaught exception at @isAnonymous
kotlin.UninitializedPropertyAccessException: There is no singleton instance. Make sure you configure Purchases before trying to get the default instance. More info here: https://errors.rev.cat/configuring-sdk
  at com.revenuecat.purchases.Purchases$Companion.getSharedInstance(Purchases.kt:1985)
  at com.revenuecat.purchases.hybridcommon.CommonKt.isAnonymous(common.kt:245)
  at com.revenuecat.purchases.PurchasesPlugin.isAnonymous(PurchasesPlugin.java:176)
  at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	...
```

The reason for the exception is that, since we are changing threads (from `JavaBridge` to `main`), the configure Javascript call returns before completing the code in `configure` and `isAnonymous` gets called (in `JavaBridge`) and it executes before the singleton instance is set.

Changing `configure` to execute in `ExecutionThread.MAIN` fixes it, since it will block that thread and no other plugin function will be called until it completes.

This is another approach to fix the same as https://github.com/RevenueCat/cordova-plugin-purchases/pull/187


[CSDK-481]

[CSDK-481]: https://revenuecats.atlassian.net/browse/CSDK-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ