### PR TITLE
Removes PurchasesPromotionalOffer

### DIFF
--- a/apiTester/offerings.ts
+++ b/apiTester/offerings.ts
@@ -5,7 +5,7 @@ import {
   PurchasesStoreProductDiscount,
   PurchasesIntroPrice,
   PurchasesOffering, PurchasesOfferings,
-  PurchasesPackage, PurchasesPromotionalOffer,
+  PurchasesPackage,
   PurchasesStoreProduct, UpgradeInfo
 } from "../www/plugin";
 
@@ -72,12 +72,4 @@ function checkUpgradeInfo(info: UpgradeInfo) {
 function checkIntroEligibility(eligibility: IntroEligibility) {
   const status: INTRO_ELIGIBILITY_STATUS = eligibility.status;
   const description: string = eligibility.description;
-}
-
-function checkPromotionalOffer(discount: PurchasesPromotionalOffer) {
-  const identifier: string = discount.identifier;
-  const keyIdentifier: string = discount.keyIdentifier;
-  const nonce: string = discount.nonce;
-  const signature: string = discount.signature;
-  const timestamp: number = discount.timestamp;
 }

--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -5,7 +5,6 @@ import {
   PurchasesError,
   PurchasesOfferings,
   PurchasesPackage,
-  PurchasesPromotionalOffer,
   PurchasesStoreProduct,
   UpgradeInfo,
   PURCHASE_TYPE, 
@@ -32,29 +31,6 @@ function checkUsers(purchases: Purchases) {
   Purchases.logOut(callback => { const customerInfo: CustomerInfo = callback; }, errorCallback);
   Purchases.getCustomerInfo(callback => { const customerInfo: CustomerInfo = callback; }, errorCallback);
   Purchases.isAnonymous(callback => { const isAnonymous: boolean = callback; });
-}
-
-function checkPurchasing(purchases: Purchases,
-                         product: PurchasesStoreProduct,
-                         discount: PurchasesStoreProductDiscount,
-                         paymentDiscount: PurchasesPromotionalOffer,
-                         pack: PurchasesPackage) {
-  const productId: string = "";
-  const upgradeInfo: UpgradeInfo | null = null;
-  const features: BILLING_FEATURE[] = [];
-  
-  const purchaseCallback = ({productIdentifier, customerInfo,}: { productIdentifier: string; customerInfo: CustomerInfo; }) => {};
-  const errorCallbackUserCancelled = ({error, userCancelled,}: { error: PurchasesError; userCancelled: boolean; }) => {};
-
-  Purchases.purchaseProduct(productId, purchaseCallback, errorCallbackUserCancelled, upgradeInfo, PURCHASE_TYPE.INAPP);
-  Purchases.purchasePackage(pack, purchaseCallback, errorCallbackUserCancelled, upgradeInfo);
-  Purchases.syncPurchases();
-
-  Purchases.canMakePayments(features, callback => { const canMakePayments: boolean = callback; }, errorCallback);
-  Purchases.getOfferings(offerings => { const offeringsData: PurchasesOfferings = offerings; }, errorCallback);
-
-  const eligibilityCallback = (map: { [productId:string]:IntroEligibility; }) => {};
-  Purchases.checkTrialOrIntroductoryPriceEligibility([""], eligibilityCallback);
 }
 
 function checkConfigure() {

--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -5,6 +5,7 @@ import {
   PurchasesError,
   PurchasesOfferings,
   PurchasesPackage,
+  PurchasesPromotionalOffer,
   PurchasesStoreProduct,
   UpgradeInfo,
   PURCHASE_TYPE, 
@@ -31,6 +32,28 @@ function checkUsers(purchases: Purchases) {
   Purchases.logOut(callback => { const customerInfo: CustomerInfo = callback; }, errorCallback);
   Purchases.getCustomerInfo(callback => { const customerInfo: CustomerInfo = callback; }, errorCallback);
   Purchases.isAnonymous(callback => { const isAnonymous: boolean = callback; });
+}
+
+function checkPurchasing(purchases: Purchases,
+                         product: PurchasesStoreProduct,
+                         discount: PurchasesStoreProductDiscount,
+                         pack: PurchasesPackage) {
+  const productId: string = "";
+  const upgradeInfo: UpgradeInfo | null = null;
+  const features: BILLING_FEATURE[] = [];
+  
+  const purchaseCallback = ({productIdentifier, customerInfo,}: { productIdentifier: string; customerInfo: CustomerInfo; }) => {};
+  const errorCallbackUserCancelled = ({error, userCancelled,}: { error: PurchasesError; userCancelled: boolean; }) => {};
+
+  Purchases.purchaseProduct(productId, purchaseCallback, errorCallbackUserCancelled, upgradeInfo, PURCHASE_TYPE.INAPP);
+  Purchases.purchasePackage(pack, purchaseCallback, errorCallbackUserCancelled, upgradeInfo);
+  Purchases.syncPurchases();
+
+  Purchases.canMakePayments(features, callback => { const canMakePayments: boolean = callback; }, errorCallback);
+  Purchases.getOfferings(offerings => { const offeringsData: PurchasesOfferings = offerings; }, errorCallback);
+
+  const eligibilityCallback = (map: { [productId:string]:IntroEligibility; }) => {};
+  Purchases.checkTrialOrIntroductoryPriceEligibility([""], eligibilityCallback);
 }
 
 function checkConfigure() {

--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -5,7 +5,6 @@ import {
   PurchasesError,
   PurchasesOfferings,
   PurchasesPackage,
-  PurchasesPromotionalOffer,
   PurchasesStoreProduct,
   UpgradeInfo,
   PURCHASE_TYPE, 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -60,14 +60,6 @@ export enum PURCHASE_TYPE {
   PRICE_CHANGE_CONFIRMATION,
 }
 
-export interface PurchasesPromotionalOffer {
-  readonly identifier: string;
-  readonly keyIdentifier: string;
-  readonly nonce: string;
-  readonly signature: string;
-  readonly timestamp: number;
-}
-
 export enum PRORATION_MODE {
   UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY = 0,
 

--- a/www/plugin.d.ts
+++ b/www/plugin.d.ts
@@ -49,13 +49,6 @@ export declare enum BILLING_FEATURE {
      */
     PRICE_CHANGE_CONFIRMATION = 4
 }
-export interface PurchasesPromotionalOffer {
-    readonly identifier: string;
-    readonly keyIdentifier: string;
-    readonly nonce: string;
-    readonly signature: string;
-    readonly timestamp: number;
-}
 export declare enum PRORATION_MODE {
     UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY = 0,
     /**


### PR DESCRIPTION
We are missing `getPromotionalOffer` and `purchaseDiscountedProduct` so this interface is useless

I added it to the SDK feature parity sheet