### PR TITLE
Fix iOS Cordova paramedic tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  macos: circleci/macos@2.3.2
   android: circleci/android@1.0
   revenuecat: revenuecat/sdks-common-config@2.1.0
 
@@ -134,6 +135,29 @@ commands:
       - run:
           name: Copy npmrc sample file to final location
           command: cp .npmrc.SAMPLE .npmrc
+  
+  install-and-create-sim:
+    parameters:
+      install-name:
+        type: string
+      sim-device-type:
+        type: string
+      sim-device-runtime:
+        type: string
+      sim-name:
+        type: string
+    steps:
+      - run:
+          name: Install xcode-install
+          command: gem install xcode-install
+      - run:
+          name: Install simulator
+          command: | # Print all available simulators and install required one
+              xcversion simulators
+              xcversion simulators --install="<< parameters.install-name >>"
+      - run:
+          name: Create simulator
+          command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
 
 jobs:
   android-integration-test:
@@ -170,13 +194,20 @@ jobs:
 
   ios-integration-test:
     description: "Run iOS integration tests for Cordova"
+    resource_class: macos.x86.medium.gen2
     macos:
-      xcode: 13.4.0
+      xcode: 13.4.1
+    shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - run:
-          name: Start simulator
-          command: xcrun instruments -w "iPhone 13 (15.4) [" || true
+      - install-and-create-sim:
+          install-name: iOS 15.4 Simulator
+          sim-device-type: iPhone-13
+          sim-device-runtime: iOS-15-4
+          sim-name: iPhone 13 (15.4)
+      - macos/preboot-simulator:
+          device: iPhone 13
+          version: '15.4'
       - npm-dependencies
       - npm-install-cordova-paramedic
       - npm-ios-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ commands:
   
   install-and-create-sim:
     parameters:
-      install-name:
+      install-simulator-name:
         type: string
       sim-device-type:
         type: string
@@ -154,7 +154,7 @@ commands:
           name: Install simulator
           command: | # Print all available simulators and install required one
               xcversion simulators
-              xcversion simulators --install="<< parameters.install-name >>"
+              xcversion simulators --install="<< parameters.install-simulator-name >>"
       - run:
           name: Create simulator
           command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
@@ -201,7 +201,7 @@ jobs:
     steps:
       - checkout
       - install-and-create-sim:
-          install-name: iOS 15.4 Simulator
+          install-simulator-name: iOS 15.4 Simulator
           sim-device-type: iPhone-13
           sim-device-runtime: iOS-15-4
           sim-name: iPhone 13 (15.4)


### PR DESCRIPTION
Upgrading to Xcode 13.4 broke the integration tests because we were getting this error: `xcrun: error: unable to find utility "instruments", not a developer tool or in PATH`

In this PR I upgraded the CI to use the macos orb, which has some tools that help with mac machines.