### PR TITLE
Adds missing parameter to bump_version_update_changelog_create_pr

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,8 @@ lane :bump do |options|
     repo_name: repo_name,
     github_rate_limit: options[:github_rate_limit],
     editor: options[:editor],
-    next_version: options[:next_version]
+    next_version: options[:next_version],
+    automatic_release: options[:automatic_release]
   )
   update_hybrids_versions_file(
     versions_file_path: './VERSIONS.md',


### PR DESCRIPTION
`bump_version_update_changelog_create_pr` was missing the `automatic_release` parameter. We pass it as `true` from the `automatic_bump` lane, but forgot to pass it to `bump_version_update_changelog_create_pr`.

This was causing automatic bump PRs to not have the `[AUTOMATIC]` text in the title. For example https://github.com/RevenueCat/cordova-plugin-purchases/pull/213, whereas this other react-native-purchases PR has the correct title https://github.com/RevenueCat/react-native-purchases/pull/458

