### PR TITLE
Fix CDVPlugin class CDVPurchasesPlugin (pluginName: purchasesplugin) does not exist bug

### DIFF
--- a/src/ios/PurchasesPlugin.swift
+++ b/src/ios/PurchasesPlugin.swift
@@ -10,7 +10,7 @@ import Foundation
 import PurchasesHybridCommon
 import RevenueCat
 
-public class CDVPurchasesPlugin : CDVPlugin {
+@objc(CDVPurchasesPlugin) public class CDVPurchasesPlugin : CDVPlugin {
 
     public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     typealias HybridResponseBlock = ([String: Any]?, ErrorContainer?) -> Void


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/cordova-plugin-purchases/issues/181

Tested it on a new Ionic + Capacitor project and this fixed the issue