### PR TITLE
Added `Purchases.setLogLevel`

### DIFF
--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -10,6 +10,7 @@ import {
   PURCHASE_TYPE, 
   PurchasesStoreProductDiscount, 
   BILLING_FEATURE,
+  LOG_LEVEL,
   ShouldPurchasePromoProductListener,
   PurchasesConfiguration
 } from '../www/plugin';
@@ -77,7 +78,18 @@ function checkConfigure() {
 
   Purchases.setProxyURL("");
   Purchases.setDebugLogsEnabled(true);
+  Purchases.setLogLevel(LOG_LEVEL.DEBUG);
   Purchases.setSimulatesAskToBuyInSandbox(true);
+}
+
+function checkLogLevels(level: LOG_LEVEL) {
+  switch (level) {
+    case LOG_LEVEL.DEBUG:
+    case LOG_LEVEL.VERBOSE:
+    case LOG_LEVEL.INFO:
+    case LOG_LEVEL.WARN:
+    case LOG_LEVEL.ERROR:
+  }
 }
 
 function checkPurchasesConfiguration() {

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -159,9 +159,16 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         CommonKt.getCustomerInfo(getOnResult(callbackContext));
     }
 
+    @Deprecated
     @PluginAction(thread = ExecutionThread.WORKER, actionName = "setDebugLogsEnabled")
     private void setDebugLogsEnabled(boolean enabled, CallbackContext callbackContext) {
         CommonKt.setDebugLogsEnabled(enabled);
+        callbackContext.success();
+    }
+
+    @PluginAction(thread = ExecutionThread.WORKER, actionName = "setLogLevel")
+    private void setLogLevel(String level, CallbackContext callbackContext) {
+        CommonKt.setLogLevel(level);
         callbackContext.success();
     }
 

--- a/src/ios/PurchasesPlugin.swift
+++ b/src/ios/PurchasesPlugin.swift
@@ -68,6 +68,17 @@ import RevenueCat
         self.sendOKFor(command: command)
     }
 
+    @objc(setLogLevel:)
+    func setLogLevel(command: CDVInvokedUrlCommand) {
+        guard let level = command.arguments[0] as? String else {
+            self.sendBadParameterFor(command: command, parameterNamed: "level", expectedType: String.self)
+            return
+        }
+
+        CommonFunctionality.setLogLevel(level)
+        self.sendOKFor(command: command)
+    }
+
 }
 
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -156,6 +156,14 @@ export enum INTRO_ELIGIBILITY_STATUS {
   INTRO_ELIGIBILITY_STATUS_NO_INTRO_OFFER_EXISTS,
 }
 
+export enum LOG_LEVEL {
+  VERBOSE = "VERBOSE",
+  DEBUG = "DEBUG",
+  INFO = "INFO",
+  WARN = "WARN",
+  ERROR = "ERROR"
+}
+
 /**
  * The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */
@@ -642,6 +650,13 @@ class Purchases {
   public static INTRO_ELIGIBILITY_STATUS = INTRO_ELIGIBILITY_STATUS;
 
   /**
+   * Enum of different possible log levels.
+   * @readonly
+   * @enum {string}
+   */
+  public static LOG_LEVEL = LOG_LEVEL;
+
+  /**
    * @deprecated Use {@link configureWith} instead. It accepts a {@link PurchasesConfiguration} object which offers more flexibility.
    *
    * Sets up Purchases with your API key and an app user id.
@@ -905,10 +920,22 @@ class Purchases {
   /**
    * Enables/Disables debugs logs
    * @param {boolean} enabled Enable or not debug logs
+   * @deprecated Use {@link setLogLevel} instead.
    */
   public static setDebugLogsEnabled(enabled: boolean): void {
     window.cordova.exec(null, null, PLUGIN_NAME, "setDebugLogsEnabled", [
       enabled,
+    ]);
+  }
+
+  /**
+   * Used to set the log level. Useful for debugging issues with the lovely team @RevenueCat.
+   * @param {boolean} enabled Enable or not debug logs
+   * @deprecated Use {@link setLogLevel} instead.
+   */
+  public static setLogLevel(level: LOG_LEVEL): void {
+    window.cordova.exec(null, null, PLUGIN_NAME, "setLogLevel", [
+      level,
     ]);
   }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -919,7 +919,7 @@ class Purchases {
 
   /**
    * Enables/Disables debugs logs
-   * @param {boolean} enabled Enable or not debug logs
+   * @param {boolean} enabled Enable or disable debug logs
    * @deprecated Use {@link setLogLevel} instead.
    */
   public static setDebugLogsEnabled(enabled: boolean): void {
@@ -930,8 +930,7 @@ class Purchases {
 
   /**
    * Used to set the log level. Useful for debugging issues with the lovely team @RevenueCat.
-   * @param {boolean} enabled Enable or not debug logs
-   * @deprecated Use {@link setLogLevel} instead.
+   * @param {LOG_LEVEL} level the minimum log level to enable.
    */
   public static setLogLevel(level: LOG_LEVEL): void {
     window.cordova.exec(null, null, PLUGIN_NAME, "setLogLevel", [


### PR DESCRIPTION
Fixes [CSDK-608].
Depends on https://github.com/RevenueCat/purchases-android/pull/753 and https://github.com/RevenueCat/purchases-hybrid-common/pull/301


[CSDK-608]: https://revenuecats.atlassian.net/browse/CSDK-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ