### PR TITLE
Fix iOS integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
   npm-dependencies:
     description: "Install all global and local npm dependencies"
     steps:
-      - run: npm install -g cordova
+      - run: npm install -g cordova@11
       - run: npm install --legacy-peer-deps
       - run: npm install -g yarn
 
@@ -189,18 +189,13 @@ jobs:
     description: "Run iOS integration tests for Cordova"
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: 13.4.1
+      xcode: 14.3.1
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-and-create-sim:
-          install-simulator-name: iOS 15.4 Simulator
-          sim-device-type: iPhone-13
-          sim-device-runtime: iOS-15-4
-          sim-name: iPhone 13 (15.4)
       - macos/preboot-simulator:
-          device: iPhone 13
-          version: '15.4'
+          device: iPhone 14
+          version: '16.4'
       - npm-dependencies
       - npm-install-cordova-paramedic
       - npm-ios-dependencies


### PR DESCRIPTION
- Fixes version in CI to Cordova 11 since Cordova Paramedic can't use Cordova 12 (same changes as in https://github.com/RevenueCat/cordova-plugin-purchases/blob/bc5-support/.circleci/config.yml#L46)
- Updated xcode version