### PR TITLE
Add metadata to offering

### DIFF
--- a/apiTester/offerings.ts
+++ b/apiTester/offerings.ts
@@ -50,6 +50,7 @@ function checkPackage(pack: PurchasesPackage) {
 function checkOffering(offering: PurchasesOffering) {
   const identifier: string = offering.identifier;
   const serverDescription: string = offering.serverDescription;
+  const metadata: Map<string, any> = offering.metadata;
   const availablePackages: PurchasesPackage[] = offering.availablePackages;
   const lifetime: PurchasesPackage | null = offering.lifetime;
   const annual: PurchasesPackage | null = offering.annual;

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -84,6 +84,10 @@ const app = {
 
         if (offerings.current !== null && offerings.current.availablePackages.length !== 0) {
           var paywallDiv = document.createElement("div")
+
+          var metadataDiv = document.createElement("div")
+          paywallDiv.appendChild(metadataDiv);
+          metadataDiv.appendChild(document.createTextNode(JSON.stringify(offerings.current.metadata)));
           
           var packages = offerings.current.availablePackages;
           packages.forEach((package) => {

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
                 <param name="android-package" value="com.revenuecat.purchases.PurchasesPlugin" />
             </feature>
         </config-file>
-        <framework src="com.revenuecat.purchases:purchases-hybrid-common:5.0.0-beta.6" />
+        <framework src="com.revenuecat.purchases:purchases-hybrid-common:5.0.0-rc.1" />
         <framework src="androidx.annotation:annotation:[1.4.0]"/>
         <source-file src="src/android/PurchasesPlugin.java" target-dir="src/com/revenuecat/purchases"/>
     </platform>
@@ -38,7 +38,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="PurchasesHybridCommon" spec="5.0.0-beta.6"/>
+                <pod name="PurchasesHybridCommon" spec="5.0.0-rc.1"/>
             </pods>
         </podspec>
     </platform>

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -532,6 +532,10 @@ export interface PurchasesOffering {
    */
   readonly serverDescription: string;
   /**
+   * Offering metadata defined in RevenueCat dashboard.
+   */
+  readonly metadata: Map<string, any>;
+  /**
    * Array of `Package` objects available for purchase.
    */
   readonly availablePackages: PurchasesPackage[];


### PR DESCRIPTION
## Motivation

Add `metadata` to `PurchasesOffering`

## Description

- Bumped Android, iOS, and macOS to hybrid common `5.0.0-rc.1`
- Added `metadata: Map<string, any>` to `PurchasesOffering`
- Updated API tester


**DID NOT** add a `getMetadataString(String key, String defaultValue)` because TypeScript interfaces 😔 

### Screenshot

<img width="421" alt="Screenshot 2023-06-07 at 3 23 47 PM" src="https://github.com/RevenueCat/cordova-plugin-purchases/assets/401294/c4039a93-9436-4c73-acb0-416128b59e87">
