### PR TITLE
`presentCodeRedemptionSheet`: disabled on Catalyst

### DIFF
--- a/src/ios/PurchasesPlugin+Purchasing.swift
+++ b/src/ios/PurchasesPlugin+Purchasing.swift
@@ -81,11 +81,20 @@ import PurchasesHybridCommon
 
     @objc(presentCodeRedemptionSheet:)
     func presentCodeRedemptionSheet(command: CDVInvokedUrlCommand) {
-        if #available(iOS 14.0, *) {
-            CommonFunctionality.presentCodeRedemptionSheet()
-        } else {
+        func logPresentCodeRedemptionSheetNotAvailable() {
             NSLog("%@", "[Purchases] Warning: tried to present codeRedemptionSheet, but it's only available on iOS 14.0 or greater.")
         }
+
+        #if targetEnvironment(macCatalyst)
+            logPresentCodeRedemptionSheetNotAvailable()
+        #else
+            if #available(iOS 14.0, *) {
+                CommonFunctionality.presentCodeRedemptionSheet()
+            } else {
+                logPresentCodeRedemptionSheetNotAvailable
+            }
+        #endif
+
         self.sendOKFor(command: command)
     }
 


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/purchases-ios/issues/2356#issuecomment-1623783559

This method [is not actually available on Catalyst](https://github.com/RevenueCat/purchases-hybrid-common/blob/2c45895568dc3dbacfa2e3c401acd2b8ed322b7e/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift#L133) (see https://github.com/RevenueCat/purchases-hybrid-common/pull/197).
