### PR TITLE
Use correct type for offering metadata

### DIFF
--- a/apiTester/offerings.ts
+++ b/apiTester/offerings.ts
@@ -62,7 +62,7 @@ function checkPackage(pack: PurchasesPackage) {
 function checkOffering(offering: PurchasesOffering) {
   const identifier: string = offering.identifier;
   const serverDescription: string = offering.serverDescription;
-  const metadata: Map<string, any> = offering.metadata;
+  const metadata: { [key: string]: unknown } = offering.metadata;
   const availablePackages: PurchasesPackage[] = offering.availablePackages;
   const lifetime: PurchasesPackage | null = offering.lifetime;
   const annual: PurchasesPackage | null = offering.annual;

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -534,7 +534,7 @@ export interface PurchasesOffering {
   /**
    * Offering metadata defined in RevenueCat dashboard.
    */
-  readonly metadata: Map<string, any>;
+  readonly metadata: { [key: string]: unknown };
   /**
    * Array of `Package` objects available for purchase.
    */


### PR DESCRIPTION
As reported in https://github.com/RevenueCat/react-native-purchases/issues/700. The typescript interface has specified the wrong type for metadata. We're not using typescript Maps, but simple objects for metadata. This should be an object of key strings and unknown values.

Cordova equivalent of https://github.com/RevenueCat/react-native-purchases/pull/702