### PR TITLE
Update offering metadata documentation with a usage example

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -532,7 +532,10 @@ export interface PurchasesOffering {
    */
   readonly serverDescription: string;
   /**
-   * Offering metadata defined in RevenueCat dashboard.
+   * Offering metadata defined in RevenueCat dashboard. To access values, you need
+   * to check the type beforehand. For example:
+   * const my_unknown_value: unknown = offering.metadata['my_key'];
+   * const my_string_value: string | undefined = typeof(my_unknown_value) === 'string' ? my_unknown_value : undefined;
    */
   readonly metadata: { [key: string]: unknown };
   /**


### PR DESCRIPTION
Added a small example of how to access offering metadata values to the documentation.
