### PR TITLE
Only update docs index on latest stable releases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 1e624200ff2ddf0d398ce072171db35d017c408b
+  revision: f88dcd4914cbce57e8024c686f0d06855d0b579c
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       rest-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 9c82c7ab8dab77383245907fd6e5184a61398cae
+  revision: 1e624200ff2ddf0d398ce072171db35d017c408b
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
+      rest-client
 
 GEM
   remote: https://rubygems.org/
@@ -16,17 +17,17 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.908.0)
-    aws-sdk-core (3.191.6)
+    aws-partitions (1.914.0)
+    aws-sdk-core (3.192.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.78.0)
+    aws-sdk-kms (1.79.0)
       aws-sdk-core (~> 3, >= 3.191.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.146.1)
-      aws-sdk-core (~> 3, >= 3.191.0)
+    aws-sdk-s3 (1.147.0)
+      aws-sdk-core (~> 3, >= 3.192.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
@@ -177,6 +178,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
@@ -188,6 +190,9 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0305)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     multi_json (1.15.0)
@@ -195,6 +200,7 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
+    netrc (0.11.0)
     nkf (0.2.0)
     no_proxy_fix (0.1.2)
     octokit (8.1.0)
@@ -202,16 +208,21 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
-    optparse (0.4.0)
+    optparse (0.5.0)
     os (1.1.4)
     plist (3.7.1)
     public_suffix (5.0.5)
-    rake (13.2.0)
+    rake (13.2.1)
     rchardet (1.8.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.2.6)
     rouge (2.0.7)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,14 +3,16 @@ files_with_version_number = {
   './package.json' => ['"version": "{x}"'],
   './plugin.xml' => ['id="cordova-plugin-purchases" version="{x}"'],
   './src/android/PurchasesPlugin.java' => ['PLUGIN_VERSION = "{x}"'],
-  './src/ios/PurchasesPlugin.swift' => ['return "{x}"'],
-  './scripts/docs/index.html' => ['cordova-plugin-purchases-docs/{x}/']
+  './src/ios/PurchasesPlugin.swift' => ['return "{x}"']
 }
 files_to_update_phc_version = {
   'plugin.xml' => [
     'name="PurchasesHybridCommon" spec="{x}"',
     'com.revenuecat.purchases:purchases-hybrid-common:{x}'
   ]
+}
+files_to_update_on_latest_stable_releases = {
+  './scripts/docs/index.html' => ['cordova-plugin-purchases-docs/{x}/']
 }
 repo_name = 'cordova-plugin-purchases'
 changelog_latest_path = './CHANGELOG.latest.md'
@@ -30,6 +32,7 @@ lane :bump do |options|
     changelog_latest_path: changelog_latest_path,
     changelog_path: changelog_path,
     files_to_update: files_with_version_number,
+    files_to_update_on_latest_stable_releases: files_to_update_on_latest_stable_releases,
     repo_name: repo_name,
     github_rate_limit: options[:github_rate_limit],
     editor: options[:editor],


### PR DESCRIPTION
### Description
Cordova equivalent of: https://github.com/RevenueCat/purchases-android/pull/1676

We updated the plugin to support a new parameter that will only be updated on stable versions (no prereleases) and as the latest version (no bigger semver versions exist)