### PR TITLE
Fix cordova ios integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,8 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - runtest
+      - android-integration-test
+      - ios-integration-test
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
     steps:
       - run:
           name: Install Cordova Paramedic
-          command: npm install --location=global github:apache/cordova-paramedic#c394568c093b13da6a1fe69546aef0a66c21a7de
+          command: npm install --location=global github:apache/cordova-paramedic#2243a96d23e9a27213cbbf17634df0beb3463bdb
 
   replace-api-key-linux:
     description: "Replace API_KEY"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,9 +187,9 @@ jobs:
 
   ios-integration-test:
     description: "Run iOS integration tests for Cordova"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 14.3.1
+      xcode: '15.2'
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,8 @@ jobs:
     steps:
       - checkout
       - macos/preboot-simulator:
-          device: iPhone 14
-          version: '16.4'
+          device: iPhone 15
+          version: '17.2'
       - npm-dependencies
       - npm-install-cordova-paramedic
       - npm-ios-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,8 +292,6 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - runtest
-      - android-integration-test
-      - ios-integration-test
 
   deploy:
     when:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepare": "tsc",
     "test": "jest",
     "test:android": "cordova-paramedic --verbose --platform android@11 --plugin .",
-    "test:ios": "cordova-paramedic --verbose --platform ios --plugin . --target \"iPhone-15, 17.2\""
+    "test:ios": "cordova-paramedic --verbose --platform ios --plugin . --target \"iPhone-15\""
   },
   "author": "RevenueCat, Inc.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepare": "tsc",
     "test": "jest",
     "test:android": "cordova-paramedic --verbose --platform android@11 --plugin .",
-    "test:ios": "cordova-paramedic --verbose --platform ios --plugin ."
+    "test:ios": "cordova-paramedic --verbose --platform ios --plugin . --target \"iPhone-15, 17.2\""
   },
   "author": "RevenueCat, Inc.",
   "license": "MIT",


### PR DESCRIPTION
This reverts back to use M1 CI machines for iOS tests. In the meantime, I updated to the latest paramedic commit and had to select the simulator (it didn't work automatically for some reason). This means we will need to update it from time to time