### PR TITLE
Add support new native majors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to use the SDK
 
 ### Requirements
-*cordova-plugin-purchases* requires Xcode 13.2+ and minimum targets iOS 11.0+. The minimum Android version compatible is 4.4 (API level 19).
+*cordova-plugin-purchases* requires Xcode 15+ and minimum targets iOS 13.0+. The minimum Android version compatible is 5.0 (API level 21).
 
 ## SDK Reference
 Our full SDK reference [can be found here](https://revenuecat.github.io/cordova-plugin-purchases-docs).

--- a/apiTester/attributes.ts
+++ b/apiTester/attributes.ts
@@ -26,6 +26,5 @@ function checkAttributes(purchases: Purchases) {
   Purchases.setCreative(stringOrNull);
 
   Purchases.collectDeviceIdentifiers();
-  Purchases.setAutomaticAppleSearchAdsAttributionCollection(true);
   Purchases.enableAdServicesAttributionTokenCollection();
 }

--- a/apiTester/enums.ts
+++ b/apiTester/enums.ts
@@ -79,6 +79,8 @@ function checkProrationMode(mode: PRORATION_MODE): boolean {
       return true;
     case PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE:
       return true;
+    case PRORATION_MODE.DEFERRED:
+      return true;
   }
 }
 

--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -19,7 +19,7 @@ import {
 } from '../www/plugin';
 
 import Purchases from '../www/plugin';
-import {IN_APP_MESSAGE_TYPE} from "../src/plugin/plugin";
+import {IN_APP_MESSAGE_TYPE, PURCHASES_ARE_COMPLETED_BY_TYPE, PurchasesAreCompletedBy, STOREKIT_VERSION} from "../src/plugin/plugin";
 
 const errorCallback = (error: PurchasesError) => {
 };
@@ -97,13 +97,11 @@ function checkConfigure() {
 
   Purchases.configure(
     apiKey,
-    appUserID,
-    observerMode
+    appUserID
   );
   Purchases.configure(
     apiKey,
     appUserID,
-    observerMode,
     userDefaultsSuiteName
   );
 
@@ -132,33 +130,34 @@ function checkLogLevels(level: LOG_LEVEL) {
 function checkPurchasesConfiguration() {
   const apiKey: string = "";
   const appUserID: string | null = "";
-  const observerMode: boolean = false;
+  const purchasesAreCompletedBy: PurchasesAreCompletedBy = PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT;
   const userDefaultsSuiteName: string = "";
   const useAmazon: boolean = false;
   const shouldShowInAppMessagesAutomatically: boolean = true;
+  const storeKitVersion: STOREKIT_VERSION = STOREKIT_VERSION.STOREKIT_2;
 
   Purchases.configureWith({
     apiKey,
     appUserID,
-    observerMode
+    purchasesAreCompletedBy
   });
   Purchases.configureWith({
     apiKey,
     appUserID,
-    observerMode,
+    purchasesAreCompletedBy,
     userDefaultsSuiteName
   });
   Purchases.configureWith({
     apiKey,
     appUserID,
-    observerMode,
+    purchasesAreCompletedBy,
     userDefaultsSuiteName,
     useAmazon
   });
   Purchases.configureWith({
     apiKey,
     appUserID,
-    observerMode,
+    purchasesAreCompletedBy,
     userDefaultsSuiteName,
     useAmazon,
     shouldShowInAppMessagesAutomatically
@@ -167,8 +166,9 @@ function checkPurchasesConfiguration() {
   const configuration: PurchasesConfiguration = {
     apiKey,
     appUserID,
-    observerMode,
+    purchasesAreCompletedBy,
     userDefaultsSuiteName,
+    storeKitVersion,
     useAmazon
   }
 
@@ -198,12 +198,14 @@ function checkListeners() {
   Purchases.removeShouldPurchasePromoProductListener(shouldPurchaseListener);
 }
 
-function checkSyncObserverModeAmazonPurchase(productID: string,
-                                             receiptID: string,
-                                             amazonUserID: string,
-                                             isoCurrencyCode?: string | null,
-                                             price?: number | null) {
+function checkSyncAmazonPurchase(productID: string,
+                                 receiptID: string,
+                                 amazonUserID: string,
+                                 isoCurrencyCode?: string | null,
+                                 price?: number | null) {
   Purchases.syncObserverModeAmazonPurchase(
+    productID, receiptID, amazonUserID, isoCurrencyCode, price);
+  Purchases.syncAmazonPurchase(
     productID, receiptID, amazonUserID, isoCurrencyCode, price);
 }
 

--- a/examples/cordova-sample/MyApp/config.xml
+++ b/examples/cordova-sample/MyApp/config.xml
@@ -24,4 +24,5 @@
         <allow-intent href="itms-apps:*" />
     </platform>
     <preference name="AndroidXEnabled" value="true" />
+    <preference name="deployment-target" value="13.0" />
 </widget>

--- a/examples/cordova-sample/MyApp/package.json
+++ b/examples/cordova-sample/MyApp/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "devDependencies": {
-    "cordova-ios": "^6.3.0",
+    "cordova-ios": "^7.1.1",
     "cordova-plugin-add-swift-support": "^2.0.2"
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
                 <param name="android-package" value="com.revenuecat.purchases.PurchasesPlugin" />
             </feature>
         </config-file>
-        <framework src="com.revenuecat.purchases:purchases-hybrid-common:11.0.0" />
+        <framework src="com.revenuecat.purchases:purchases-hybrid-common:13.0.1" />
         <framework src="androidx.annotation:annotation:[1.4.0]"/>
         <source-file src="src/android/PurchasesPlugin.java" target-dir="src/com/revenuecat/purchases"/>
     </platform>
@@ -38,7 +38,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="PurchasesHybridCommon" spec="11.0.0"/>
+                <pod name="PurchasesHybridCommon" spec="13.0.1"/>
             </pods>
         </podspec>
     </platform>

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -44,8 +44,8 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
     // Otherwise, the configure plugin call will complete before configure finishes, and
     // other calls to the plugin will fail with UninitializedPropertyAccessException
     @PluginAction(thread = ExecutionThread.MAIN, actionName = "configure", isAutofinish = false)
-    private void configure(String apiKey, @Nullable String appUserID, boolean observerMode,
-                           @Nullable String userDefaultsSuiteName, boolean usesStoreKit2IfAvailable,
+    private void configure(String apiKey, @Nullable String appUserID, @Nullable String purchasesAreCompletedBy,
+                           @Nullable String userDefaultsSuiteName, @Nullable String storeKitVersion,
                            boolean useAmazon, boolean shouldShowInAppMessagesAutomatically,
                            CallbackContext callbackContext) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
@@ -53,8 +53,7 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         if (useAmazon) {
             store = Store.AMAZON;
         }
-        CommonKt.configure(this.cordova.getActivity(), apiKey, appUserID,
-            observerMode ? PurchasesAreCompletedBy.MY_APP : PurchasesAreCompletedBy.REVENUECAT,
+        CommonKt.configure(this.cordova.getActivity(), apiKey, appUserID, purchasesAreCompletedBy,
             platformInfo, store, new DangerousSettings(), shouldShowInAppMessagesAutomatically);
         callbackContext.success();
     }
@@ -240,11 +239,6 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
 
     @PluginAction(thread = ExecutionThread.WORKER, actionName = "setSimulatesAskToBuyInSandbox")
     private void setSimulatesAskToBuyInSandbox(boolean enabled, CallbackContext callbackContext) {
-        // NOOP
-    }
-
-    @PluginAction(thread = ExecutionThread.WORKER, actionName = "setAutomaticAppleSearchAdsAttributionCollection")
-    private void setAutomaticAppleSearchAdsAttributionCollection(boolean enabled, CallbackContext callbackContext) {
         // NOOP
     }
 

--- a/src/ios/PurchasesPlugin+Attribution.swift
+++ b/src/ios/PurchasesPlugin+Attribution.swift
@@ -10,19 +10,6 @@ import PurchasesHybridCommon
 
 @objc public extension CDVPurchasesPlugin {
 
-    @objc(setAutomaticAppleSearchAdsAttributionCollection:)
-    func setAutomaticAppleSearchAdsAttributionCollection(command: CDVInvokedUrlCommand) {
-        guard let automaticCollection = command.arguments[0] as? Bool else {
-            self.sendBadParameterFor(command: command,
-                                     parameterNamed: "AutomaticAppleSearchAdsAttributionCollection",
-                                     expectedType: Bool.self)
-            return
-        }
-
-        CommonFunctionality.setAutomaticAppleSearchAdsAttributionCollection(automaticCollection)
-        self.sendOKFor(command: command)
-    }
-
     @objc(enableAdServicesAttributionTokenCollection:)
     func enableAdServicesAttributionTokenCollection(command: CDVInvokedUrlCommand) {
         if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {

--- a/src/ios/PurchasesPlugin.swift
+++ b/src/ios/PurchasesPlugin.swift
@@ -36,18 +36,18 @@ import RevenueCat
             return
         }
         let appUserID = command.arguments[1] as? String
-        let observerMode = command.arguments[2] as? Bool ?? false
+        let purchasesAreCompletedBy = command.arguments[2] as? String ?? nil
         let userDefaultsSuiteName = command.arguments[3] as? String
-        let usesStoreKit2IfAvailable = command.arguments[4] as? Bool ?? false
+        let storeKitVersion = command.arguments[4] as? String ?? "DEFAULT"
         let shouldShowInAppMessagesAutomatically = command.arguments[5] as? Bool ?? true
 
         self.purchases = Purchases.configure(apiKey: apiKey,
                                              appUserID: appUserID,
-                                             purchasesAreCompletedBy: observerMode ? .myApp : .revenueCat,
+                                             purchasesAreCompletedBy: purchasesAreCompletedBy,
                                              userDefaultsSuiteName: userDefaultsSuiteName,
                                              platformFlavor: self.platformFlavor,
                                              platformFlavorVersion: self.platformFlavorVersion,
-                                             usesStoreKit2IfAvailable: usesStoreKit2IfAvailable,
+                                             storeKitVersion: storeKitVersion,
                                              dangerousSettings: nil,
                                              shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically)
         self.purchases.delegate = self

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -105,6 +105,14 @@ export enum PRORATION_MODE {
    * plus remaining prorated time from the old plan.
    */
   IMMEDIATE_AND_CHARGE_FULL_PRICE = 5,
+
+  /**
+   * Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+   *
+   * Example: Samwise's Tier 1 subscription continues until it expires on April 30. On May 1st, the
+   * Tier 2 subscription takes effect, and Samwise is charged $36 for his new subscription tier.
+   */
+  DEFERRED = 6,
 }
 
 export enum PACKAGE_TYPE {
@@ -668,6 +676,85 @@ export interface LogInResult {
 }
 
 /**
+ * Defines which version of StoreKit may be used
+ */
+export enum STOREKIT_VERSION {
+  /**
+   * Always use StoreKit 1.
+   */
+  STOREKIT_1 = "STOREKIT_1",
+  /**
+   * Always use StoreKit 2 (StoreKit 1 will be used if StoreKit 2 is not available in the current device.)
+   * - Warning: Make sure you have an In-App Purchase Key configured in your app.
+   * Please see https://rev.cat/in-app-purchase-key-configuration for more info.
+   */
+  STOREKIT_2 = "STOREKIT_2",
+  /**
+   * Let RevenueCat use the most appropiate version of StoreKit
+   */
+  DEFAULT = "DEFAULT",
+}
+
+/**
+ * Modes for completing the purchase process.
+ */
+export enum PURCHASES_ARE_COMPLETED_BY_TYPE {
+  /**
+   * RevenueCat will **not** automatically acknowledge any purchases. You will have to do so manually.
+   *
+   * **Note:** failing to acknowledge a purchase within 3 days will lead to Google Play automatically issuing a
+   * refund to the user.
+   *
+   * For more info, see [revenuecat.com](https://docs.revenuecat.com/docs/observer-mode#option-2-client-side).
+   */
+  MY_APP = "MY_APP",
+  /**
+   * RevenueCat will automatically acknowledge verified purchases. No action is required by you.
+   */
+  REVENUECAT = "REVENUECAT",
+}
+
+/**
+ * Configuration option that specifies that your app will complete purchases.
+ */
+export type PurchasesAreCompletedByMyApp = {
+  type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
+
+  /**
+   * The version of StoreKit that your app is using to make purchases. This value is ignored
+   * on Android, so if your app is Android-only, you may provide any value.
+   */
+  storeKitVersion: STOREKIT_VERSION;
+}
+
+/**
+ * Allows you to specify whether you want RevenueCat to complete your app's purchases
+ * or if your app will do so.
+ *
+ * You can configure RevenueCat to complete your purchases like so:
+ * ```typescript
+ * Purchases.configure({
+ *  apiKey: "123",
+ *  purchasesAreCompletedBy: PURCHASES_ARE_COMPLETED_BY.REVENUECAT,
+ * });
+ * ```
+ *
+ * You can specify that purchase are completed by your app like so:
+ * ```typescript
+ * Purchases.configure({
+ *  apiKey: "123",
+ *  purchasesAreCompletedBy: {
+ *    type: PURCHASES_ARE_COMPLETED_BY.MY_APP,
+ *    storeKitVersion: STOREKIT_VERSION.STOREKIT_1
+ *  },
+ * });
+ * ```
+ */
+export type PurchasesAreCompletedBy =
+  | PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT
+  | PurchasesAreCompletedByMyApp;
+
+/**
  * Holds parameters to initialize the SDK.
  */
 export interface PurchasesConfiguration {
@@ -680,11 +767,14 @@ export interface PurchasesConfiguration {
    */
   appUserID?: string | null;
   /**
-   * An optional boolean. Set this to TRUE if you have your own IAP implementation and
-   * want to use only RevenueCat's backend. Default is FALSE. If you are on Android and setting this to ON, you will have
-   * to acknowledge the purchases yourself.
+   * Set this to MY_APP and provide a STOREKIT_VERSION if you have your own IAP implementation and
+   * want to only use RevenueCat's backend. Defaults to PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT.
+   *
+   * If you are on Android and setting this to MY_APP, will have to acknowledge the purchases yourself.
+   * If your app is only on Android, you may specify any StoreKit version, as it is ignored by the
+   * Android SDK.
    */
-  observerMode?: boolean;
+  purchasesAreCompletedBy?: PurchasesAreCompletedBy;
   /**
    * An optional string. iOS-only, will be ignored for Android.
    * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults
@@ -693,16 +783,17 @@ export interface PurchasesConfiguration {
   userDefaultsSuiteName?: string;
   /**
    * iOS-only, will be ignored for Android.
-   * Set this to TRUE to enable StoreKit2.
-   * Default is FALSE.
    *
-   * @deprecated RevenueCat currently uses StoreKit 1 for purchases, as its stability in production scenarios has
-   * proven to be more performant than StoreKit 2.
-   * We're collecting more data on the best approach, but StoreKit 1 vs StoreKit 2 is an implementation detail
-   * that you shouldn't need to care about.
-   * We recommend not using this parameter, letting RevenueCat decide for you which StoreKit implementation to use.
+   * By selecting the DEFAULT value, RevenueCat will automatically select the most appropriate StoreKit version
+   * for the app's runtime environment.
+   *
+   * - Warning: Make sure you have an In-App Purchase Key configured in your app.
+   * Please see https://rev.cat/in-app-purchase-key-configuration for more info.
+   *
+   * - Note: StoreKit 2 is only available on iOS 16+. StoreKit 1 will be used for previous iOS versions
+   * regardless of this setting.
    */
-  usesStoreKit2IfAvailable?: boolean;
+  storeKitVersion?: STOREKIT_VERSION;
   /**
    * An optional boolean. Android only. Required to configure the plugin to be used in the Amazon Appstore.
    */
@@ -1000,14 +1091,25 @@ class Purchases {
   public static IN_APP_MESSAGE_TYPE = IN_APP_MESSAGE_TYPE;
 
   /**
+   * Modes for completing the purchase process.
+   * @readonly
+   * @enum {string}
+   */
+  public static PURCHASES_ARE_COMPLETED_BY_TYPE = PURCHASES_ARE_COMPLETED_BY_TYPE;
+
+  /**
+   * Defines which version of StoreKit may be used.
+   * @readonly
+   * @enum {string}
+   */
+  public static STOREKIT_VERSION = STOREKIT_VERSION;
+
+  /**
    * @deprecated Use {@link configureWith} instead. It accepts a {@link PurchasesConfiguration} object which offers more flexibility.
    *
    * Sets up Purchases with your API key and an app user id.
    * @param {string} apiKey RevenueCat API Key. Needs to be a string
    * @param {string?} appUserID A unique id for identifying the user
-   * @param {boolean} observerMode An optional boolean. Set this to TRUE if you have your own IAP implementation and
-   * want to use only RevenueCat's backend. Default is FALSE. If you are on Android and setting this to ON, you will have
-   * to acknowledge the purchases yourself.
    * @param {string?} userDefaultsSuiteName An optional string. iOS-only, will be ignored for Android.
    * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults
    * suite, otherwise it will use standardUserDefaults. Default is null, which will make the SDK use standardUserDefaults.
@@ -1015,13 +1117,11 @@ class Purchases {
   public static configure(
     apiKey: string,
     appUserID?: string | null,
-    observerMode: boolean = false,
     userDefaultsSuiteName?: string
   ): void {
     this.configureWith({
       apiKey,
       appUserID,
-      observerMode,
       userDefaultsSuiteName,
       useAmazon: false
     })
@@ -1034,18 +1134,35 @@ class Purchases {
   public static configureWith({
                                 apiKey,
                                 appUserID = null,
-                                observerMode = false,
+                                purchasesAreCompletedBy,
                                 userDefaultsSuiteName,
-                                usesStoreKit2IfAvailable = false,
+                                storeKitVersion,
                                 useAmazon = false,
                                 shouldShowInAppMessagesAutomatically = true
                               }: PurchasesConfiguration): void {
+    let purchasesCompletedByToUse: PURCHASES_ARE_COMPLETED_BY_TYPE | undefined = purchasesAreCompletedBy === PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT ? PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT : undefined;
+    let storeKitVersionToUse = storeKitVersion;
+
+    if (purchasesAreCompletedBy && Purchases.isPurchasesAreCompletedByMyApp(purchasesAreCompletedBy)) {
+      purchasesCompletedByToUse = PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
+      storeKitVersionToUse = purchasesAreCompletedBy.storeKitVersion;
+
+      if (storeKitVersionToUse !== storeKitVersion) {
+        // Typically, console messages aren't used in TS libraries, but in this case it's worth calling out the difference in
+        // StoreKit versions, and since the difference isn't possible farther down the call chain, we should go ahead
+        // and log it here.
+        // tslint:disable-next-line:no-console
+        console.warn(
+          "Warning: The storeKitVersion in purchasesAreCompletedBy does not match the function's storeKitVersion parameter. We will use the value found in purchasesAreCompletedBy."
+        );
+      }
+    }
     window.cordova.exec(
       null,
       null,
       PLUGIN_NAME,
       "configure",
-      [apiKey, appUserID, observerMode, userDefaultsSuiteName, usesStoreKit2IfAvailable,
+      [apiKey, appUserID, purchasesCompletedByToUse, userDefaultsSuiteName, storeKitVersionToUse,
         useAmazon, shouldShowInAppMessagesAutomatically]
     );
 
@@ -1429,6 +1546,7 @@ class Purchases {
   }
 
   /**
+   * @deprecated Use {@link syncAmazonPurchase} instead.
    * This method will send a purchase to the RevenueCat backend. This function should only be called if you are
    * in Amazon observer mode or performing a client side migration of your current users to RevenueCat.
    *
@@ -1443,27 +1561,30 @@ class Purchases {
   public static syncObserverModeAmazonPurchase(productID: string, receiptID: string,
                                                amazonUserID: string, isoCurrencyCode?: string | null,
                                                price?: number | null): void {
-    window.cordova.exec(
-      null,
-      null,
-      PLUGIN_NAME,
-      "syncObserverModeAmazonPurchase",
-      [productID, receiptID, amazonUserID, isoCurrencyCode, price]);
+    this.syncAmazonPurchase(productID, receiptID, amazonUserID, isoCurrencyCode, price);
   }
 
   /**
-   * Enable automatic collection of Apple Search Ads attribution. Disabled by default.
+   * This method will send a purchase to the RevenueCat backend. This function should only be called if you are
+   * in Amazon observer mode or performing a client side migration of your current users to RevenueCat.
    *
-   * @param {boolean} enabled Enable or not automatic collection
+   * The receipt IDs are cached if successfully posted so they are not posted more than once.
+   *
+   * @param {string} productID Product ID associated to the purchase.
+   * @param {string} receiptID ReceiptId that represents the Amazon purchase.
+   * @param {string} amazonUserID Amazon's userID. This parameter will be ignored when syncing a Google purchase.
+   * @param {(string|null|undefined)} isoCurrencyCode Product's currency code in ISO 4217 format.
+   * @param {(number|null|undefined)} price Product's price.
    */
-  public static setAutomaticAppleSearchAdsAttributionCollection(enabled: boolean): void {
-    window.cordova.exec(
+  public static syncAmazonPurchase(productID: string, receiptID: string,
+    amazonUserID: string, isoCurrencyCode?: string | null,
+    price?: number | null): void {
+      window.cordova.exec(
       null,
       null,
       PLUGIN_NAME,
-      "setAutomaticAppleSearchAdsAttributionCollection",
-      [enabled]
-    );
+      "syncAmazonPurchase",
+      [productID, receiptID, amazonUserID, isoCurrencyCode, price]);
   }
 
   /**
@@ -2078,6 +2199,17 @@ class Purchases {
       default:
         return REFUND_REQUEST_STATUS.ERROR;
     }
+  }
+
+  private static isPurchasesAreCompletedByMyApp(
+    obj: PurchasesAreCompletedBy
+  ): obj is PurchasesAreCompletedByMyApp {
+    return (
+      typeof obj === "object" &&
+      obj !== null &&
+      (obj as PurchasesAreCompletedByMyApp).type ===
+        PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP
+    );
   }
 }
 

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -1,5 +1,5 @@
 import Purchases from "../src/plugin/plugin";
-import {LOG_LEVEL, PurchasesError, PurchasesEntitlementInfo, PurchasesStoreProduct, PRODUCT_CATEGORY} from "../www/plugin";
+import {LOG_LEVEL, PurchasesError, PurchasesEntitlementInfo, PurchasesStoreProduct, PRODUCT_CATEGORY, PURCHASES_ARE_COMPLETED_BY_TYPE, STOREKIT_VERSION, PurchasesAreCompletedByMyApp} from "../www/plugin";
 
 const execFn = jest.fn();
 
@@ -16,7 +16,7 @@ describe("Purchases", () => {
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", false, undefined, false, false, true]
+      ["api_key", "app_user_id", undefined, undefined, undefined, false, true]
     );
   });
 
@@ -28,59 +28,58 @@ describe("Purchases", () => {
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", false, undefined, false, false, true]
+      ["api_key", "app_user_id", undefined, undefined, undefined, false, true]
     );
   });
 
   it("configure fires PurchasesPlugin with the correct arguments when specifying observermode", () => {
-    Purchases.configure("api_key", "app_user_id", true);
+    Purchases.configure("api_key", "app_user_id");
 
     expect(execFn).toHaveBeenCalledWith(
       null,
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", true, undefined, false, false, true]
+      ["api_key", "app_user_id", undefined, undefined, undefined, false, true]
     );
   });
 
-  it("configureWith fires PurchasesPlugin with the correct arguments when specifying observermode", () => {
-    Purchases.configureWith({apiKey: "api_key", appUserID: "app_user_id", observerMode: true});
+  it("configureWith fires PurchasesPlugin with the correct arguments when specifying PurchasesAreCompletedBy.REVENUECAT", () => {
+    Purchases.configureWith({apiKey: "api_key", appUserID: "app_user_id", purchasesAreCompletedBy: PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT});
 
     expect(execFn).toHaveBeenCalledWith(
       null,
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", true, undefined, false, false, true]
+      ["api_key", "app_user_id", "REVENUECAT", undefined, undefined, false, true]
+    );
+  });
+
+  it("configureWith fires PurchasesPlugin with the correct arguments when specifying PurchasesAreCompletedByMyApp", () => {
+    let purchasesAreCompletedByMyApp: PurchasesAreCompletedByMyApp = {type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP, storeKitVersion: STOREKIT_VERSION.STOREKIT_2};
+    Purchases.configureWith({apiKey: "api_key", appUserID: "app_user_id", purchasesAreCompletedBy: purchasesAreCompletedByMyApp});
+
+    expect(execFn).toHaveBeenCalledWith(
+      null,
+      null,
+      "PurchasesPlugin",
+      "configure",
+      ["api_key", "app_user_id", "MY_APP", undefined, "STOREKIT_2", false, true]
     );
   });
 
   it("configure fires PurchasesPlugin with the correct arguments when setting user defaults suite name", () => {
     const expected = "suite-name";
 
-    Purchases.configure("api_key", "app_user_id", false, expected);
+    Purchases.configure("api_key", "app_user_id", expected);
 
     expect(execFn).toHaveBeenCalledWith(
       null,
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", false, expected, false, false, true]
-    );
-  });
-
-  it("configure fires PurchasesPlugin with the correct arguments when setting user defaults suite name", () => {
-    const expected = "suite-name";
-
-    Purchases.configure("api_key", "app_user_id", false, expected);
-
-    expect(execFn).toHaveBeenCalledWith(
-      null,
-      null,
-      "PurchasesPlugin",
-      "configure",
-      ["api_key", "app_user_id", false, expected, false, false, true]
+      ["api_key", "app_user_id", undefined, expected, undefined, false, true]
     );
   });
 
@@ -92,19 +91,19 @@ describe("Purchases", () => {
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", false, undefined, false, true, true]
+      ["api_key", "app_user_id", undefined, undefined, undefined, true, true]
     );
   });
 
   it("configureWith fires PurchasesPlugin with the correct arguments when using StoreKit 2", () => {
-    Purchases.configureWith({apiKey: "api_key", appUserID: "app_user_id", usesStoreKit2IfAvailable: true});
+    Purchases.configureWith({apiKey: "api_key", appUserID: "app_user_id", storeKitVersion: STOREKIT_VERSION.STOREKIT_2});
 
     expect(execFn).toHaveBeenCalledWith(
       null,
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", false, undefined, true, false, true]
+      ["api_key", "app_user_id", undefined, undefined, "STOREKIT_2", false, true]
     );
   });
 
@@ -116,7 +115,7 @@ describe("Purchases", () => {
       null,
       "PurchasesPlugin",
       "configure",
-      ["api_key", "app_user_id", false, undefined, false, true, false]
+      ["api_key", "app_user_id", undefined, undefined, undefined, true, false]
     );
   });
 
@@ -678,9 +677,9 @@ describe("Purchases", () => {
     });
   });
 
-  describe("syncObserverModeAmazonPurchase", () => {
+  describe("syncAmazonPurchase", () => {
     it("calls Purchases with the correct arguments", () => {
-      Purchases.syncObserverModeAmazonPurchase(
+      Purchases.syncAmazonPurchase(
           'productID_test',
           'receiptID_test',
           'amazonUserID_test',
@@ -692,7 +691,7 @@ describe("Purchases", () => {
           null,
           null,
           "PurchasesPlugin",
-          "syncObserverModeAmazonPurchase",
+          "syncAmazonPurchase",
           [
             'productID_test',
             'receiptID_test',


### PR DESCRIPTION
This bumps PHC to 13.0.0 which includes breaking changes in the native SDKs: 
- iOS v5: https://github.com/RevenueCat/purchases-ios/releases/tag/5.0.0
- Android v8: https://github.com/RevenueCat/purchases-android/releases/tag/8.0.0