### PR TITLE
Support displaying deferred win-back StoreKit messages

### DIFF
--- a/apiTester/enums.ts
+++ b/apiTester/enums.ts
@@ -92,5 +92,7 @@ function checkInAppMessageType(messageType: IN_APP_MESSAGE_TYPE): boolean {
       return true;
     case IN_APP_MESSAGE_TYPE.GENERIC:
       return true;
+    case IN_APP_MESSAGE_TYPE.WIN_BACK_OFFER:
+      return true;
   }
 }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -212,7 +212,13 @@ export enum IN_APP_MESSAGE_TYPE {
   /**
    * iOS-only. StoreKit generic messages.
    */
-  GENERIC = 2
+  GENERIC = 2,
+
+  /**
+   * iOS-only. This message will show if the subscriber is eligible for an iOS win-back
+   * offer and will allow the subscriber to redeem the offer.
+   */
+  WIN_BACK_OFFER = 3
 }
 
 /**

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -325,12 +325,13 @@ describe("Purchases", () => {
     });
     describe("when list of parameters are passed", () => {
       it("parameters are mapped successfully", () => {
-        const expected = [[0, 2, 1]]
+        const expected = [[0, 2, 1, 3]]
 
         Purchases.showInAppMessages(
           [Purchases.IN_APP_MESSAGE_TYPE.BILLING_ISSUE,
             Purchases.IN_APP_MESSAGE_TYPE.GENERIC,
-            Purchases.IN_APP_MESSAGE_TYPE.PRICE_INCREASE_CONSENT],
+            Purchases.IN_APP_MESSAGE_TYPE.PRICE_INCREASE_CONSENT,
+            Purchases.IN_APP_MESSAGE_TYPE.WIN_BACK_OFFER],
         );
         expect(execFn).toHaveBeenCalledWith(
           null,


### PR DESCRIPTION
This PR introduces the ability for a developer to display deferred StoreKit win-back offer messages to the user. The functionality was originally introduced in https://github.com/RevenueCat/purchases-ios/pull/4343.

Other than the enum addition, no other changes are necessary.