### PR TITLE
Support Fetching and Redeeming Win-Back Offers on Custom Paywall

### DIFF
--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -234,14 +234,12 @@ function checkFetchAndPurchaseWinBackOffersForProduct(
   Purchases.getEligibleWinBackOffersForProduct(
     product,
     (winBackOffers) => {
-      if (winBackOffers.length > 0) {
-        Purchases.purchaseProductWithWinBackOffer(
-          product,
-          winBackOffers[0],
-          ({productIdentifier, customerInfo}) => {},
-          ({error, userCancelled}) => {}
-        );
-      }
+      Purchases.purchaseProductWithWinBackOffer(
+        product,
+        winBackOffers[0],
+        ({productIdentifier, customerInfo}) => {},
+        ({error, userCancelled}) => {}
+      );
     },
     errorCallback
   );
@@ -253,14 +251,12 @@ function checkFetchAndPurchaseWinBackOffersForPackage(
   Purchases.getEligibleWinBackOffersForPackage(
     aPackage,
     (winBackOffers) => {
-      if (winBackOffers.length > 0) {
-        Purchases.purchasePackageWithWinBackOffer(
-          aPackage,
-          winBackOffers[0],
-          ({productIdentifier, customerInfo}) => {},
-          ({error, userCancelled}) => {}
-        );
-      }
+      Purchases.purchasePackageWithWinBackOffer(
+        aPackage,
+        winBackOffers[0],
+        ({productIdentifier, customerInfo}) => {},
+        ({error, userCancelled}) => {}
+      );
     },
     errorCallback
   );

--- a/apiTester/purchases.ts
+++ b/apiTester/purchases.ts
@@ -227,3 +227,41 @@ function checkBeginRefundRequest(
   Purchases.beginRefundRequestForProduct(purchasesStoreProduct, (refundRequestStatus: REFUND_REQUEST_STATUS) => {
   }, errorCallback);
 }
+
+function checkFetchAndPurchaseWinBackOffersForProduct(
+  product: PurchasesStoreProduct,
+) {
+  Purchases.getEligibleWinBackOffersForProduct(
+    product,
+    (winBackOffers) => {
+      if (winBackOffers.length > 0) {
+        Purchases.purchaseProductWithWinBackOffer(
+          product,
+          winBackOffers[0],
+          ({productIdentifier, customerInfo}) => {},
+          ({error, userCancelled}) => {}
+        );
+      }
+    },
+    errorCallback
+  );
+}
+
+function checkFetchAndPurchaseWinBackOffersForPackage(
+  aPackage: PurchasesPackage,
+) {
+  Purchases.getEligibleWinBackOffersForPackage(
+    aPackage,
+    (winBackOffers) => {
+      if (winBackOffers.length > 0) {
+        Purchases.purchasePackageWithWinBackOffer(
+          aPackage,
+          winBackOffers[0],
+          ({productIdentifier, customerInfo}) => {},
+          ({error, userCancelled}) => {}
+        );
+      }
+    },
+    errorCallback
+  );
+}

--- a/examples/cordova-sample/MyApp/RevenueCatTest.storekit
+++ b/examples/cordova-sample/MyApp/RevenueCatTest.storekit
@@ -1,4 +1,14 @@
 {
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
   "identifier" : "3B56BC8C",
   "nonRenewingSubscriptions" : [
 
@@ -51,7 +61,60 @@
     }
   ],
   "settings" : {
-
+    "_compatibilityTimeRate" : {
+      "3" : 6
+    },
+    "_failTransactionsEnabled" : false,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ],
+    "_timeRate" : 1002
   },
   "subscriptionGroups" : [
     {
@@ -84,7 +147,10 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Test Increase 29.99 -> 49.99",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         },
         {
           "adHocOffers" : [
@@ -109,7 +175,10 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Monthly $10.99",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         },
         {
           "adHocOffers" : [
@@ -138,7 +207,17 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Monthly $4.99, 1-week free",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+            {
+              "internalID" : "D11E21B6",
+              "isEligible" : true,
+              "offerID" : "winback.1m0",
+              "paymentMode" : "free",
+              "referenceName" : "Winback 1m0",
+              "subscriptionPeriod" : "P1M"
+            }
+          ]
         },
         {
           "adHocOffers" : [
@@ -192,7 +271,45 @@
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "Annual $39.99, 2-weeks free",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "4.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "FB2C956C",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "Monthly $4.99",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.monthly_4.99",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Monthly $4.99",
+          "subscriptionGroupID" : "D833F705",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+            {
+              "internalID" : "D11E21B6",
+              "isEligible" : true,
+              "offerID" : "winback.1m0",
+              "paymentMode" : "free",
+              "referenceName" : "Winback 1m0",
+              "subscriptionPeriod" : "P1M"
+            }
+          ]
         }
       ]
     },
@@ -226,13 +343,16 @@
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "Annual $39.99, 1-week free",
           "subscriptionGroupID" : "CAB34497",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         }
       ]
     }
   ],
   "version" : {
-    "major" : 1,
-    "minor" : 2
+    "major" : 4,
+    "minor" : 0
   }
 }

--- a/examples/cordova-sample/MyApp/RevenueCatTest.storekit
+++ b/examples/cordova-sample/MyApp/RevenueCatTest.storekit
@@ -182,45 +182,6 @@
         },
         {
           "adHocOffers" : [
-
-          ],
-          "codeOffers" : [
-
-          ],
-          "displayPrice" : "4.99",
-          "familyShareable" : false,
-          "groupNumber" : 1,
-          "internalID" : "9D3DBCD0",
-          "introductoryOffer" : {
-            "internalID" : "56E28AFE",
-            "paymentMode" : "free",
-            "subscriptionPeriod" : "P1W"
-          },
-          "localizations" : [
-            {
-              "description" : "",
-              "displayName" : "Monthly $4.99, 1-week free",
-              "locale" : "en_US"
-            }
-          ],
-          "productID" : "com.revenuecat.monthly_4.99.1_week_intro",
-          "recurringSubscriptionPeriod" : "P1M",
-          "referenceName" : "Monthly $4.99, 1-week free",
-          "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription",
-          "winbackOffers" : [
-            {
-              "internalID" : "D11E21B6",
-              "isEligible" : true,
-              "offerID" : "winback.1m0",
-              "paymentMode" : "free",
-              "referenceName" : "Winback 1m0",
-              "subscriptionPeriod" : "P1M"
-            }
-          ]
-        },
-        {
-          "adHocOffers" : [
             {
               "displayPrice" : "4.00",
               "internalID" : "05E9D55A",
@@ -308,6 +269,41 @@
               "paymentMode" : "free",
               "referenceName" : "Winback 1m0",
               "subscriptionPeriod" : "P1M"
+            }
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "4.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "4AF169E0",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "Monthly $4.99",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.monthly_4.99.1_week_intro",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Monthly $4.99 1 week intro",
+          "subscriptionGroupID" : "D833F705",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+            {
+              "internalID" : "D11E21B6",
+              "isEligible" : true,
+              "offerID" : "winback.2m0",
+              "paymentMode" : "free",
+              "referenceName" : "Winback 2m0",
+              "subscriptionPeriod" : "P2M"
             }
           ]
         }

--- a/examples/cordova-sample/MyApp/www/index.html
+++ b/examples/cordova-sample/MyApp/www/index.html
@@ -69,6 +69,12 @@
                 <button id="record-purchase" type="button" class="tester-button">Record purchase</button>
 
                 <button id="prototype-button" type="button" class="tester-button" style="display:none">Prototype Button</button>
+
+                <button id="load-and-purchase-product-for-winback-testing" type="button" class="tester-button">Purchase Product for Winback Testing</button>
+                <button id="fetch-and-purchase-eligible-winback-offers-for-product" type="button" class="tester-button">Fetch and Purchase Eligible Winback Offers for Product</button>
+
+                <button id="load-and-purchase-package-for-winback-testing" type="button" class="tester-button">Purchase Package for Winback Testing</button>
+                <button id="fetch-and-purchase-eligible-winback-offers-for-package" type="button" class="tester-button">Fetch and Purchase Eligible Winback Offers for Package</button>
             </div>
         </div>
         <script type="text/javascript" src="cordova.js"></script>

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -529,7 +529,7 @@ const app = {
                   product,
                   winBackOffer,
                   ({ productIdentifier, customerInfo }) => {
-                     setStatusLabelText("product identifier: " + productIdentifier)
+                     setStatusLabelText({ productIdentifier, customerInfo });
                   },
                   ({ error, userCancelled }) => {
                     setStatusLabelText({ 'error': error, 'userCancelled': userCancelled });

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -47,6 +47,15 @@ const app = {
     document.getElementById("show-in-app-messages").addEventListener("click", this.showInAppMessages)
     document.getElementById("record-purchase").addEventListener("click", this.recordPurchase)
     document
+      .getElementById("load-and-purchase-product-for-winback-testing")
+      .addEventListener("click", this.loadProductForWinbackTesting);
+    document
+      .getElementById("fetch-and-purchase-eligible-winback-offers-for-product")
+      .addEventListener(
+        "click",
+        this.fetchAndPurchaseEligibleWinbackOffersForProduct
+      );
+    document
       .getElementById("load-and-purchase-package-for-winback-testing")
       .addEventListener("click", this.loadPackageForWinbackTesting);
     document

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -48,7 +48,7 @@ const app = {
     document.getElementById("record-purchase").addEventListener("click", this.recordPurchase)
     document
       .getElementById("load-and-purchase-product-for-winback-testing")
-      .addEventListener("click", this.loadProductForWinbackTesting);
+      .addEventListener("click", this.loadAndPurchaseProductForWinbackTesting);
     document
       .getElementById("fetch-and-purchase-eligible-winback-offers-for-product")
       .addEventListener(
@@ -57,7 +57,7 @@ const app = {
       );
     document
       .getElementById("load-and-purchase-package-for-winback-testing")
-      .addEventListener("click", this.loadPackageForWinbackTesting);
+      .addEventListener("click", this.loadAndPurchasePackageForWinbackTesting);
     document
       .getElementById("fetch-and-purchase-eligible-winback-offers-for-package")
       .addEventListener(
@@ -482,7 +482,7 @@ const app = {
     );
   },
 
-  loadProductForWinbackTesting: function() {
+  loadAndPurchaseProductForWinbackTesting: function() {
     Purchases.getProducts(["com.revenuecat.monthly_4.99"], products => {
       if (products && products.length > 0) {
         const product = products[0];
@@ -529,10 +529,10 @@ const app = {
                   product,
                   winBackOffer,
                   ({ productIdentifier, customerInfo }) => {
-                    setStatusLabelText({ productIdentifier, customerInfo });
+                     setStatusLabelText("product identifier: " + productIdentifier)
                   },
                   ({ error, userCancelled }) => {
-                    setStatusLabelText({ error, userCancelled });
+                    setStatusLabelText({ 'error': error, 'userCancelled': userCancelled });
                   }
                 );
               } else {
@@ -555,7 +555,7 @@ const app = {
     );
   },
 
-  loadPackageForWinbackTesting: function() {
+  loadAndPurchasePackageForWinbackTesting: function() {
     setStatusLabelText("Loading package for winback testing");
     Purchases.getOfferings(
       offerings => {
@@ -581,7 +581,7 @@ const app = {
                 setStatusLabelText({ productIdentifier, customerInfo });
               },
               ({ error, userCancelled }) => {
-                setStatusLabelText({ error, userCancelled });
+                setStatusLabelText({ 'error': error, 'userCancelled': userCancelled });
               }
             );
           } else {

--- a/examples/cordova-sample/MyApp/www/js/index.js
+++ b/examples/cordova-sample/MyApp/www/js/index.js
@@ -46,6 +46,15 @@ const app = {
     document.getElementById("begin-refund-request-product-id").addEventListener("click", this.beginRefundRequestForProduct)
     document.getElementById("show-in-app-messages").addEventListener("click", this.showInAppMessages)
     document.getElementById("record-purchase").addEventListener("click", this.recordPurchase)
+    document
+      .getElementById("load-and-purchase-package-for-winback-testing")
+      .addEventListener("click", this.loadPackageForWinbackTesting);
+    document
+      .getElementById("fetch-and-purchase-eligible-winback-offers-for-package")
+      .addEventListener(
+        "click",
+        this.fetchAndPurchaseEligibleWinbackOffersForPackage
+      );
   },
 
   // deviceready Event Handler
@@ -462,8 +471,183 @@ const app = {
         setStatusLabelText(error);
       }
     );
-  }
+  },
 
+  loadProductForWinbackTesting: function() {
+    Purchases.getProducts(["com.revenuecat.monthly_4.99"], products => {
+      if (products && products.length > 0) {
+        const product = products[0];
+        Purchases.purchaseProduct(
+          product.identifier,
+          customerInfo => {
+            setStatusLabelText(customerInfo);
+          },
+          error => {
+            setStatusLabelText(error);
+          }
+        );
+      } else {
+        setStatusLabelText("No product found");
+      }
+    });
+  },
+
+  fetchAndPurchaseEligibleWinbackOffersForProduct: function() {
+    setStatusLabelText(
+      "fetching and purchasing eligible winback offers for product"
+    );
+    Purchases.getProducts(
+      ["com.revenuecat.monthly_4.99"],
+      products => {
+        if (products && products.length > 0) {
+          const product = products[0];
+          setStatusLabelText(
+            "About to fetch eligible winback offers for product"
+          );
+          Purchases.getEligibleWinBackOffersForProduct(
+            product,
+            winBackOffers => {
+              setStatusLabelText(
+                "Winback offers: " + JSON.stringify(winBackOffers)
+              );
+
+              if (winBackOffers && winBackOffers.length > 0) {
+                const winBackOffer = winBackOffers[0];
+                setStatusLabelText(
+                  "About to purchase product with winback offer"
+                );
+                Purchases.purchaseProductWithWinBackOffer(
+                  product,
+                  winBackOffer,
+                  ({ productIdentifier, customerInfo }) => {
+                    setStatusLabelText({ productIdentifier, customerInfo });
+                  },
+                  ({ error, userCancelled }) => {
+                    setStatusLabelText({ error, userCancelled });
+                  }
+                );
+              } else {
+                setStatusLabelText("No eligible winback offers found");
+              }
+            },
+            error => {
+              setStatusLabelText(
+                "Error getting winback offers: " + JSON.stringify(error)
+              );
+            }
+          );
+        } else {
+          setStatusLabelText("No product found");
+        }
+      },
+      error => {
+        setStatusLabelText("Error getting products: " + JSON.stringify(error));
+      }
+    );
+  },
+
+  loadPackageForWinbackTesting: function() {
+    setStatusLabelText("Loading package for winback testing");
+    Purchases.getOfferings(
+      offerings => {
+        setStatusLabelText("Got offerings: " + JSON.stringify(offerings));
+        if (
+          offerings &&
+          offerings.current &&
+          offerings.current.availablePackages
+        ) {
+          const package = offerings.current.availablePackages.find(
+            pkg =>
+              pkg.product.identifier ===
+              "com.revenuecat.monthly_4.99.1_week_intro"
+          );
+          if (package) {
+            setStatusLabelText(
+              "Found package with product: " + package.product.identifier
+            );
+
+            Purchases.purchasePackage(
+              package,
+              ({ productIdentifier, customerInfo }) => {
+                setStatusLabelText({ productIdentifier, customerInfo });
+              },
+              ({ error, userCancelled }) => {
+                setStatusLabelText({ error, userCancelled });
+              }
+            );
+          } else {
+            setStatusLabelText(
+              "Could not find package with product com.revenuecat.monthly_4.99.1_week_intro"
+            );
+          }
+        } else {
+          setStatusLabelText("No packages available in current offering");
+        }
+      },
+      error => {
+        setStatusLabelText("Error getting offerings: " + JSON.stringify(error));
+      }
+    );
+  },
+
+  fetchAndPurchaseEligibleWinbackOffersForPackage: function() {
+    setStatusLabelText("Loading package for winback testing");
+    Purchases.getOfferings(
+      offerings => {
+        setStatusLabelText("Got offerings: " + JSON.stringify(offerings));
+        if (
+          offerings &&
+          offerings.current &&
+          offerings.current.availablePackages
+        ) {
+          const package = offerings.current.availablePackages.find(
+            pkg =>
+              pkg.product.identifier ===
+              "com.revenuecat.monthly_4.99.1_week_intro"
+          );
+          if (package) {
+            setStatusLabelText(
+              "Found package with product: " + package.product.identifier
+            );
+
+            Purchases.getEligibleWinBackOffersForPackage(
+              package,
+              winBackOffers => {
+                setStatusLabelText("Got win back offers: " + JSON.stringify(winBackOffers));
+                if (winBackOffers && winBackOffers.length > 0) {
+                  const winBackOffer = winBackOffers[0];
+                  Purchases.purchasePackageWithWinBackOffer(
+                    package,
+                    winBackOffer,
+                    ({ productIdentifier, customerInfo }) => {
+                      setStatusLabelText({ productIdentifier, customerInfo });
+                    },
+                    ({ error, userCancelled }) => {
+                      setStatusLabelText({ error, userCancelled });
+                    }
+                  );
+                } else {
+                  setStatusLabelText("No win back offers available");
+                }
+              },
+              error => {
+                setStatusLabelText("Error getting win back offers: " + JSON.stringify(error));
+              }
+            );
+          } else {
+            setStatusLabelText(
+              "Could not find package with product com.revenuecat.monthly_4.99.1_week_intro"
+            );
+          }
+        } else {
+          setStatusLabelText("No packages available in current offering");
+        }
+      },
+      error => {
+        setStatusLabelText("Error getting offerings: " + JSON.stringify(error));
+      }
+    );
+  },
 };
 
 initializePurchasesSDK = function() {

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -119,7 +119,7 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
     }
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "purchasePackageWithWinBackOffer")
-    private void purchaseProductWithWinBackOffer(
+    private void purchasePackageWithWinBackOffer(
         String productIdentifier, 
         String offeringIdentifier,
         String winBackOfferIdentifier,

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -106,6 +106,29 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         });
     }
 
+    @PluginAction(thread = ExecutionThread.UI, actionName = "getEligibleWinBackOffersForProduct")
+    private void getEligibleWinBackOffersForProduct(String productIdentifier, CallbackContext callbackContext) {
+        // NOOP
+        callbackContext.error(new JSONObject());
+    }
+
+    @PluginAction(thread = ExecutionThread.UI, actionName = "purchaseProductWithWinBackOffer")
+    private void purchaseProductWithWinBackOffer(String productIdentifier, String winBackOfferIdentifier, CallbackContext callbackContext) {
+        // NOOP
+        callbackContext.error(new JSONObject());
+    }
+
+    @PluginAction(thread = ExecutionThread.UI, actionName = "purchasePackageWithWinBackOffer")
+    private void purchaseProductWithWinBackOffer(
+        String productIdentifier, 
+        String offeringIdentifier,
+        String winBackOfferIdentifier,
+        CallbackContext callbackContext
+    ) {
+        // NOOP
+        callbackContext.error(new JSONObject());
+    }
+
     @PluginAction(thread = ExecutionThread.UI, actionName = "purchaseProduct", isAutofinish = false)
     private void purchaseProduct(final String productIdentifier,
                                  @Nullable final String oldSKU,

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -10,7 +10,9 @@ import com.appfeel.cordova.annotated.android.plugin.AnnotatedCordovaPlugin;
 import com.appfeel.cordova.annotated.android.plugin.ExecutionThread;
 import com.appfeel.cordova.annotated.android.plugin.PluginAction;
 import com.revenuecat.purchases.DangerousSettings;
+import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.common.PlatformInfo;
+import com.revenuecat.purchases.PurchasesErrorCode;
 import com.revenuecat.purchases.hybridcommon.CommonKt;
 import com.revenuecat.purchases.hybridcommon.ErrorContainer;
 import com.revenuecat.purchases.hybridcommon.OnResult;
@@ -18,6 +20,7 @@ import com.revenuecat.purchases.hybridcommon.OnResultAny;
 import com.revenuecat.purchases.hybridcommon.OnResultList;
 import com.revenuecat.purchases.hybridcommon.SubscriberAttributesKt;
 import com.revenuecat.purchases.hybridcommon.mappers.CustomerInfoMapperKt;
+import com.revenuecat.purchases.hybridcommon.mappers.PurchasesErrorKt;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
 import com.revenuecat.purchases.models.InAppMessageType;
 
@@ -109,24 +112,54 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
     @PluginAction(thread = ExecutionThread.UI, actionName = "getEligibleWinBackOffersForProduct")
     private void getEligibleWinBackOffersForProduct(String productIdentifier, CallbackContext callbackContext) {
         // NOOP
-        callbackContext.error(new JSONObject());
+        PurchasesError error = new PurchasesError(
+            PurchasesErrorCode.UnsupportedError,
+            "Win-back offers are not supported on Android."
+        );
+
+        ErrorContainer errorContainer = PurchasesErrorKt.map(
+            error,
+            new HashMap<>()
+        );
+
+        callbackContext.error(convertMapToJson(errorContainer.getInfo()));
     }
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "purchaseProductWithWinBackOffer")
     private void purchaseProductWithWinBackOffer(String productIdentifier, String winBackOfferIdentifier, CallbackContext callbackContext) {
         // NOOP
-        callbackContext.error(new JSONObject());
+        PurchasesError error = new PurchasesError(
+            PurchasesErrorCode.UnsupportedError,
+            "Win-back offers are not supported on Android."
+        );
+
+        ErrorContainer errorContainer = PurchasesErrorKt.map(
+            error,
+            new HashMap<>()
+        );
+
+        callbackContext.error(convertMapToJson(errorContainer.getInfo()));
     }
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "purchasePackageWithWinBackOffer")
     private void purchasePackageWithWinBackOffer(
-        String productIdentifier, 
+        String productIdentifier,
         String offeringIdentifier,
         String winBackOfferIdentifier,
         CallbackContext callbackContext
     ) {
         // NOOP
-        callbackContext.error(new JSONObject());
+        PurchasesError error = new PurchasesError(
+            PurchasesErrorCode.UnsupportedError,
+            "Win-back offers are not supported on Android."
+        );
+
+        ErrorContainer errorContainer = PurchasesErrorKt.map(
+            error,
+            new HashMap<>()
+        );
+
+        callbackContext.error(convertMapToJson(errorContainer.getInfo()));
     }
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "purchaseProduct", isAutofinish = false)

--- a/src/ios/PurchasesPlugin+Purchasing.swift
+++ b/src/ios/PurchasesPlugin+Purchasing.swift
@@ -28,6 +28,38 @@ import PurchasesHybridCommon
         }
     }
 
+    @objc(getEligibleWinBackOffersForProduct:)
+    func getEligibleWinBackOffersForProduct(command: CDVInvokedUrlCommand) {
+        guard let productIdentifier = command.arguments[0] as? String else {
+            self.sendBadParameterFor(command: command, parameterNamed: "productIdentifier", expectedType: String.self)
+            return
+        }
+
+        CommonFunctionality.eligibleWinBackOffers(for: productIdentifier) { eligibleOffers, error in
+            self.sendOKFor(command: command, messageAsArray: eligibleOffers)
+        }
+    }
+
+    @objc(purchaseProductWithWinBackOffer:)
+    func purchaseProductWithWinBackOffer(command: CDVInvokedUrlCommand) {
+        guard let productIdentifier = command.arguments[0] as? String else {
+            self.sendBadParameterFor(command: command, parameterNamed: "productIdentifier", expectedType: String.self)
+            return
+        }
+
+        guard let winBackOfferIdentifier = command.arguments[1] as? String else {
+            self.sendBadParameterFor(command: command, parameterNamed: "winBackOfferIdentifier", expectedType: String.self)
+            return
+        }
+
+      
+        CommonFunctionality.purchase(
+            product: productIdentifier,
+            winBackOfferID: winBackOfferIdentifier,
+            completion: self.responseCompletion(forCommand: command)
+        )
+    }
+
     @objc(purchaseProduct:)
     func purchaseProduct(command: CDVInvokedUrlCommand) {
         guard let productIdentifier = command.arguments[0] as? String else {

--- a/src/ios/PurchasesPlugin+Purchasing.swift
+++ b/src/ios/PurchasesPlugin+Purchasing.swift
@@ -64,6 +64,31 @@ import PurchasesHybridCommon
         )
     }
 
+    @objc(purchasePackageWithWinBackOffer:)
+    func purchasePackageWithWinBackOffer(command: CDVInvokedUrlCommand) {
+        guard let packageIdentifier = command.arguments[0] as? String else {
+            self.sendBadParameterFor(command: command, parameterNamed: "packageIdentifier", expectedType: String.self)
+            return
+        }
+
+        guard let offeringIdentifier = command.arguments[1] as? String else {
+            self.sendBadParameterFor(command: command, parameterNamed: "offeringIdentifier", expectedType: String.self)
+            return
+        }
+
+        guard let winBackOfferIdentifier = command.arguments[2] as? String else {
+            self.sendBadParameterFor(command: command, parameterNamed: "winBackOfferIdentifier", expectedType: String.self)
+            return
+        }
+
+        CommonFunctionality.purchase(
+            package: packageIdentifier,
+            presentedOfferingContext: ["offeringIdentifier": offeringIdentifier],
+            winBackOfferID: winBackOfferIdentifier,
+            completion: self.responseCompletion(forCommand: command)
+        )
+    }
+
     @objc(purchaseProduct:)
     func purchaseProduct(command: CDVInvokedUrlCommand) {
         guard let productIdentifier = command.arguments[0] as? String else {

--- a/src/ios/PurchasesPlugin+Purchasing.swift
+++ b/src/ios/PurchasesPlugin+Purchasing.swift
@@ -57,7 +57,6 @@ import PurchasesHybridCommon
             return
         }
 
-      
         CommonFunctionality.purchase(
             product: productIdentifier,
             winBackOfferID: winBackOfferIdentifier,

--- a/src/ios/PurchasesPlugin+Purchasing.swift
+++ b/src/ios/PurchasesPlugin+Purchasing.swift
@@ -35,13 +35,18 @@ import PurchasesHybridCommon
             return
         }
 
-        CommonFunctionality.eligibleWinBackOffers(for: productIdentifier) { eligibleOffers, error in
-          if let error = error {
-              let result = CDVPluginResult(status: .error, messageAs: error.info)
-              self.commandDelegate.send(result, callbackId: command.callbackId)
-          } else {
-            self.sendOKFor(command: command, messageAsArray: eligibleOffers)
-          }
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            CommonFunctionality.eligibleWinBackOffers(for: productIdentifier) { eligibleOffers, error in
+                if let error = error {
+                    let result = CDVPluginResult(status: .error, messageAs: error.info)
+                    self.commandDelegate.send(result, callbackId: command.callbackId)
+                } else {
+                    self.sendOKFor(command: command, messageAsArray: eligibleOffers)
+                }
+            }
+        } else {
+            NSLog("[Purchases] Warning: tried to call fetch eligible win-back offers, but it's only available on iOS 18.0+")
+            sendUnsupportedErrorFor(command: command)
         }
     }
 
@@ -57,11 +62,16 @@ import PurchasesHybridCommon
             return
         }
 
-        CommonFunctionality.purchase(
-            product: productIdentifier,
-            winBackOfferID: winBackOfferIdentifier,
-            completion: self.responseCompletion(forCommand: command)
-        )
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            CommonFunctionality.purchase(
+                product: productIdentifier,
+                winBackOfferID: winBackOfferIdentifier,
+                completion: self.responseCompletion(forCommand: command)
+            )
+        } else {
+            NSLog("[Purchases] Warning: tried to purchase a product with a win-back offer, but win-back offers are only available on iOS 18.0+")
+            sendUnsupportedErrorFor(command: command)
+        }
     }
 
     @objc(purchasePackageWithWinBackOffer:)
@@ -81,12 +91,17 @@ import PurchasesHybridCommon
             return
         }
 
-        CommonFunctionality.purchase(
-            package: packageIdentifier,
-            presentedOfferingContext: ["offeringIdentifier": offeringIdentifier],
-            winBackOfferID: winBackOfferIdentifier,
-            completion: self.responseCompletion(forCommand: command)
-        )
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            CommonFunctionality.purchase(
+                package: packageIdentifier,
+                presentedOfferingContext: ["offeringIdentifier": offeringIdentifier],
+                winBackOfferID: winBackOfferIdentifier,
+                completion: self.responseCompletion(forCommand: command)
+            )
+        } else {
+            NSLog("[Purchases] Warning: tried to purchase a package with a win-back offer, but win-back offers are only available on iOS 18.0+")
+            sendUnsupportedErrorFor(command: command)
+        }
     }
 
     @objc(purchaseProduct:)

--- a/src/ios/PurchasesPlugin+Purchasing.swift
+++ b/src/ios/PurchasesPlugin+Purchasing.swift
@@ -36,7 +36,12 @@ import PurchasesHybridCommon
         }
 
         CommonFunctionality.eligibleWinBackOffers(for: productIdentifier) { eligibleOffers, error in
+          if let error = error {
+              let result = CDVPluginResult(status: .error, messageAs: error.info)
+              self.commandDelegate.send(result, callbackId: command.callbackId)
+          } else {
             self.sendOKFor(command: command, messageAsArray: eligibleOffers)
+          }
         }
     }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1234,7 +1234,7 @@ class Purchases {
   }
 
   /**
-   * iOS only. Use this function to retrieve the eligible win-back offers that a subscriber
+   * iOS 18.0+ only. Use this function to retrieve the eligible win-back offers that a subscriber
    * is eligible for for a given product.
    *
    * @param {PurchasesStoreProduct} product The product the user intends to purchase.
@@ -1257,7 +1257,8 @@ class Purchases {
   }
 
   /**
-   * iOS only. Use this function to purchase a product with a win-back offer. Fetch eligible win-back offers with getEligibleWinBackOffersForProduct.
+   * iOS 18.0+ only. Use this function to purchase a product with a win-back offer.
+   * Fetch eligible win-back offers with getEligibleWinBackOffersForProduct.
    *
    * @param {PurchasesStoreProduct} product The product the user intends to purchase.
    * @param {PurchasesWinBackOffer} winBackOffer The win-back offer the user intends to purchase.
@@ -1286,7 +1287,7 @@ class Purchases {
   }
 
   /**
-   * iOS only. Use this function to retrieve the eligible win-back offers that a subscriber
+   * iOS 18.0+ only. Use this function to retrieve the eligible win-back offers that a subscriber
    * is eligible for for a given package.
    *
    * @param {PurchasesPackage} package The package the user intends to purchase.
@@ -1309,7 +1310,8 @@ class Purchases {
   }
 
   /**
-   * iOS only. Use this function to purchase a product with a win-back offer. Fetch eligible win-back offers with getEligibleWinBackOffersForProduct.
+   * iOS 18.0+ only. Use this function to purchase a product with a win-back offer. 
+   * Fetch eligible win-back offers with getEligibleWinBackOffersForProduct.
    *
    * @param {PurchasesPackage} aPackage The package the user intends to purchase.
    * @param {PurchasesWinBackOffer} winBackOffer The win-back offer the user intends to purchase.

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1315,7 +1315,7 @@ class Purchases {
    *
    * @param {PurchasesPackage} aPackage The package the user intends to purchase.
    * @param {PurchasesWinBackOffer} winBackOffer The win-back offer the user intends to purchase.
-   * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchaseProductWithWinBackOffer call.
+   * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchasePackageWithWinBackOffer call.
    * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error.
    */
   public static async purchasePackageWithWinBackOffer(

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1285,7 +1285,6 @@ class Purchases {
     );
   }
 
-    /**
   /**
    * iOS only. Use this function to retrieve the eligible win-back offers that a subscriber
    * is eligible for for a given package.

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1261,8 +1261,8 @@ class Purchases {
    *
    * @param {PurchasesStoreProduct} product The product the user intends to purchase.
    * @param {PurchasesWinBackOffer} winBackOffer The win-back offer the user intends to purchase.
-   * @param {function(PurchasesWinBackOffer[]):void} callback Callback triggered after a successful purchaseProductWithWinBackOffer call.
-   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error.
+   * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchaseProductWithWinBackOffer call.
+   * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error.
    */
   public static async purchaseProductWithWinBackOffer(
     product: PurchasesStoreProduct,
@@ -1313,8 +1313,8 @@ class Purchases {
    *
    * @param {PurchasesPackage} aPackage The package the user intends to purchase.
    * @param {PurchasesWinBackOffer} winBackOffer The win-back offer the user intends to purchase.
-   * @param {function(PurchasesWinBackOffer[]):void} callback Callback triggered after a successful purchaseProductWithWinBackOffer call.
-   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error.
+   * @param {function(string, CustomerInfo):void} callback Callback triggered after a successful purchaseProductWithWinBackOffer call.
+   * @param {function(PurchasesError, boolean):void} errorCallback Callback triggered after an error.
    */
   public static async purchasePackageWithWinBackOffer(
     aPackage: PurchasesPackage,

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1333,7 +1333,7 @@ class Purchases {
       },
       PLUGIN_NAME,
       "purchasePackageWithWinBackOffer",
-      [aPackage.product.identifier, aPackage.offeringIdentifier, winBackOffer.identifier]
+      [aPackage.identifier, aPackage.offeringIdentifier, winBackOffer.identifier]
     );
   }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -445,6 +445,8 @@ export interface PurchasesStoreProductDiscount {
   readonly periodNumberOfUnits: number;
 }
 
+export interface PurchasesWinBackOffer extends PurchasesStoreProductDiscount {}
+
 export interface PurchasesStoreProduct {
   /**
    * Product Id.
@@ -1228,6 +1230,29 @@ class Purchases {
       PLUGIN_NAME,
       "getProducts",
       [productIdentifiers, type]
+    );
+  }
+
+  /**
+   * iOS only. Use this function to retrieve the eligible win-back offers that a subscriber
+   * is eligible for for a given product.
+   *
+   * @param {PurchasesStoreProduct} product The product the user intends to purchase.
+   * @param {function(PurchasesWinBackOffer[]):void} callback Callback triggered after a successful getEligibleWinBackOffersForProduct call.
+   * It will receive an array of eligible win-back objects for the provided product.
+   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error or when retrieving eligible win-back offers.
+   */
+  public static async getEligibleWinBackOffersForProduct(
+    product: PurchasesStoreProduct,
+    callback: (products: PurchasesWinBackOffer[]) => void,
+    errorCallback: (error: PurchasesError) => void
+  ) {
+    window.cordova.exec(
+      callback,
+      errorCallback,
+      PLUGIN_NAME,
+      "getEligibleWinBackOffersForProduct",
+      [product.identifier]
     );
   }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1332,8 +1332,8 @@ class Purchases {
         });
       },
       PLUGIN_NAME,
-      "purchaseProductWithWinBackOffer",
-      [aPackage.product.identifier, winBackOffer.identifier]
+      "purchasePackageWithWinBackOffer",
+      [aPackage.product.identifier, aPackage.offeringIdentifier, winBackOffer.identifier]
     );
   }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1240,11 +1240,11 @@ class Purchases {
    * @param {PurchasesStoreProduct} product The product the user intends to purchase.
    * @param {function(PurchasesWinBackOffer[]):void} callback Callback triggered after a successful getEligibleWinBackOffersForProduct call.
    * It will receive an array of eligible win-back objects for the provided product.
-   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error or when retrieving eligible win-back offers.
+   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error when retrieving eligible win-back offers.
    */
   public static async getEligibleWinBackOffersForProduct(
     product: PurchasesStoreProduct,
-    callback: (products: PurchasesWinBackOffer[]) => void,
+    callback: (winBackOffers: PurchasesWinBackOffer[]) => void,
     errorCallback: (error: PurchasesError) => void
   ) {
     window.cordova.exec(
@@ -1253,6 +1253,87 @@ class Purchases {
       PLUGIN_NAME,
       "getEligibleWinBackOffersForProduct",
       [product.identifier]
+    );
+  }
+
+  /**
+   * iOS only. Use this function to purchase a product with a win-back offer. Fetch eligible win-back offers with getEligibleWinBackOffersForProduct.
+   *
+   * @param {PurchasesStoreProduct} product The product the user intends to purchase.
+   * @param {PurchasesWinBackOffer} winBackOffer The win-back offer the user intends to purchase.
+   * @param {function(PurchasesWinBackOffer[]):void} callback Callback triggered after a successful purchaseProductWithWinBackOffer call.
+   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error.
+   */
+  public static async purchaseProductWithWinBackOffer(
+    product: PurchasesStoreProduct,
+    winBackOffer: PurchasesWinBackOffer,
+    callback: ({productIdentifier, customerInfo,}: { productIdentifier: string; customerInfo: CustomerInfo; }) => void,
+    errorCallback: ({error, userCancelled,}: { error: PurchasesError; userCancelled: boolean; }) => void,
+  ) {
+    window.cordova.exec(
+      callback,
+      (response: { [key: string]: any }) => {
+        const { userCancelled, ...error } = response;
+        errorCallback({
+          error: error as PurchasesError,
+          userCancelled,
+        });
+      },
+      PLUGIN_NAME,
+      "purchaseProductWithWinBackOffer",
+      [product.identifier, winBackOffer.identifier]
+    );
+  }
+
+    /**
+   * iOS only. Use this function to retrieve the eligible win-back offers that a subscriber
+   * is eligible for for a given package.
+   *
+   * @param {PurchasesPackage} package The package the user intends to purchase.
+   * @param {function(PurchasesWinBackOffer[]):void} callback Callback triggered after a successful getEligibleWinBackOffersForPackage call.
+   * It will receive an array of eligible win-back objects for the provided package.
+   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error when retrieving eligible win-back offers.
+   */
+  public static async getEligibleWinBackOffersForPackage(
+    aPackage: PurchasesPackage,
+    callback: (winBackOffers: PurchasesWinBackOffer[]) => void,
+    errorCallback: (error: PurchasesError) => void
+  ) {
+    window.cordova.exec(
+      callback,
+      errorCallback,
+      PLUGIN_NAME,
+      "getEligibleWinBackOffersForProduct",
+      [aPackage.product.identifier]
+    );
+  }
+
+  /**
+   * iOS only. Use this function to purchase a product with a win-back offer. Fetch eligible win-back offers with getEligibleWinBackOffersForProduct.
+   *
+   * @param {PurchasesPackage} aPackage The package the user intends to purchase.
+   * @param {PurchasesWinBackOffer} winBackOffer The win-back offer the user intends to purchase.
+   * @param {function(PurchasesWinBackOffer[]):void} callback Callback triggered after a successful purchaseProductWithWinBackOffer call.
+   * @param {function(PurchasesError):void} errorCallback Callback triggered after an error.
+   */
+  public static async purchasePackageWithWinBackOffer(
+    aPackage: PurchasesPackage,
+    winBackOffer: PurchasesWinBackOffer,
+    callback: ({productIdentifier, customerInfo,}: { productIdentifier: string; customerInfo: CustomerInfo; }) => void,
+    errorCallback: ({error, userCancelled,}: { error: PurchasesError; userCancelled: boolean; }) => void,
+  ) {
+    window.cordova.exec(
+      callback,
+      (response: { [key: string]: any }) => {
+        const { userCancelled, ...error } = response;
+        errorCallback({
+          error: error as PurchasesError,
+          userCancelled,
+        });
+      },
+      PLUGIN_NAME,
+      "purchaseProductWithWinBackOffer",
+      [aPackage.product.identifier, winBackOffer.identifier]
     );
   }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1286,6 +1286,7 @@ class Purchases {
   }
 
     /**
+  /**
    * iOS only. Use this function to retrieve the eligible win-back offers that a subscriber
    * is eligible for for a given package.
    *


### PR DESCRIPTION
This PR exposes four new functions to allow developers to fetch & redeem win-back offers that a subscriber is eligible for in their custom paywalls. These functions only function on iOS 18.0+ and require StoreKit 2 to be used.

### Fetching Eligible Win-Back Offers
```typescript
 public static async getEligibleWinBackOffersForProduct(
    product: PurchasesStoreProduct,
    callback: (winBackOffers: PurchasesWinBackOffer[]) => void,
    errorCallback: (error: PurchasesError) => void
  )

public static async getEligibleWinBackOffersForPackage(
    aPackage: PurchasesPackage,
    callback: (winBackOffers: PurchasesWinBackOffer[]) => void,
    errorCallback: (error: PurchasesError) => void
  )
```

### Redeeming Win-Back Offers
```typescript
public static async purchaseProductWithWinBackOffer(
    product: PurchasesStoreProduct,
    winBackOffer: PurchasesWinBackOffer,
    callback: ({productIdentifier, customerInfo,}: { productIdentifier: string; customerInfo: CustomerInfo; }) => void,
    errorCallback: ({error, userCancelled,}: { error: PurchasesError; userCancelled: boolean; }) => void,
  )

public static async getEligibleWinBackOffersForPackage(
    aPackage: PurchasesPackage,
    callback: (winBackOffers: PurchasesWinBackOffer[]) => void,
    errorCallback: (error: PurchasesError) => void
  )
```

### Other Changes
The PurchaseTester app was updated with a new screen to support testing these flows

### Testing
All flows were tested manually through the new screen in the PurchaseTester app.
