### PR TITLE
Document PREPAID periodType

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -238,7 +238,7 @@ export interface PurchasesEntitlementInfo {
    */
   readonly willRenew: boolean;
   /**
-   * The last period type this entitlement was in. Either: NORMAL, INTRO, TRIAL.
+   * The last period type this entitlement was in. Either: NORMAL, INTRO, TRIAL, PREPAID.
    */
   readonly periodType: string;
   /**


### PR DESCRIPTION
Documents the PREPAID `periodType` value, introduced in https://github.com/RevenueCat/purchases-hybrid-common/pull/1054. Since the value is coming from PurchasesHybridCommon, this should be all we need to do to support the new periodType case in Cordova.