### PR TITLE
Fix API tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,14 +113,14 @@ commands:
   install-nvm:
     steps:
       - run:
-          name: Install node 16.13.1
+          name: Install node 18.20.7
           command: |
             curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
             echo 'export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-      - run: nvm install 16.13.1
-      - run: nvm use 16.13.1
-      - run: echo 'nvm use 16.13.1' >> $BASH_ENV
+      - run: nvm install 18.20.7
+      - run: nvm use 18.20.7
+      - run: echo 'nvm use 18.20.7' >> $BASH_ENV
       - run: node -v
 
   copy-npm-rc:

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "tslint-config-prettier": "^1.18.0",
     "typedoc": "^0.21.0",
     "typescript": "^4.2.0"
+  },
+  "overrides": {
+    "@types/babel__traverse": "7.20.6"
   }
 }


### PR DESCRIPTION
This PR fixes the API tests that broke recently due to a dependency version update by:
- Using node 18.20.7
- Overriding the babe__traverse types library to a working version

This shouldn't affect SDK customers, since it's only used internally for our library.