### PR TITLE
[v6] Update fastlane plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ commands:
       - run:
           name: Copy npmrc sample file to final location
           command: cp .npmrc.SAMPLE .npmrc
-  
+
   install-and-create-sim:
     parameters:
       install-simulator-name:
@@ -282,6 +282,21 @@ jobs:
             open_pr:true \
             automatic_release:<< pipeline.parameters.automatic >>
 
+  insert-changelog-latest-in-main-if-needed:
+    description: "If the release corresponds to a previous version, creates a PR to insert the release changelog into main's CHANGELOG.md"
+    docker:
+      - image: cimg/ruby:2.6
+    steps:
+      - checkout
+      - revenuecat/trust-github-key
+      - revenuecat/setup-git-credentials
+      - run:
+          name: Insert changelog latest in main if needed
+          command: |
+            bundle exec fastlane insert_changelog_latest_in_main_if_needed \
+            version:<< pipeline.parameters.version >> \
+            automatic_release:<< pipeline.parameters.automatic >>
+
 workflows:
   version: 2
   build-test:
@@ -289,7 +304,7 @@ workflows:
       and:
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        # Only run this workflow when the action is "build" (the default), 
+        # Only run this workflow when the action is "build" (the default),
         # so it doesn't run for other actions like "bump" on a release branch,
         # which should only open the release PR but not deploy it.
         # (Deployment happens after the hold job is approved on the release PR.)
@@ -318,6 +333,10 @@ workflows:
       - make-release:
           <<: *release-tags
       - docs-deploy:
+          <<: *release-tags
+          requires:
+            - make-release
+      - insert-changelog-latest-in-main-if-needed:
           <<: *release-tags
           requires:
             - make-release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: db640e8eec35ef25db152097dd737e0b36992682
+  revision: a8770fd8fde3263444bc2881812b6f737b6a705b
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 1593f78d0b9b24b48238337666183e3ba82f848e
+  revision: db640e8eec35ef25db152097dd737e0b36992682
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,6 +181,23 @@ lane :generate_docs do
   end
 end
 
+desc "If the release corresponds to a previous version, creates a PR to insert the release changelog into main's CHANGELOG.md"
+lane :insert_changelog_latest_in_main_if_needed do |options|
+  if options[:dry_run]
+    dry_run = true
+  else
+    dry_run = false
+  end
+
+  insert_changelog_of_older_version(
+    sdk_version: current_version_number,
+    changelog_path: changelog_path,
+    changelog_latest_path: changelog_latest_path,
+    repo_name: repo_name,
+    dry_run: dry_run
+  )
+end
+
 ###############################################################################
 # Helper functions 🤜🤛                                                      #
 ###############################################################################

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -69,6 +69,14 @@ Update hybrid common in plugin.xml and pushes changes to a new branch if open_pr
 
 Generate docs
 
+### insert_changelog_latest_in_main_if_needed
+
+```sh
+[bundle exec] fastlane insert_changelog_latest_in_main_if_needed
+```
+
+If the release corresponds to a previous version, creates a PR to insert the release changelog into main's CHANGELOG.md
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
Follow-up of #740

Bumps [fastlane-plugin-revenuecat_internal](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal) from `1593f78` to `a8770fd`.

See full diff in <a href="https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/compare/7d97553e9c5baabcd18286f03d8034797a27dd64...1593f78d0b9b24b48238337666183e3ba82f848e">compare view</a></li>

This version of fastlane-plugin-revenuecat_internal includes the new `insert_changelog_latest_in_main_if_needed` action that creates a PR into `main` to insert the changelog of a new release of a previous major into `main`'s changelog.

This PR also implements that new `insert_changelog_latest_in_main_if_needed`