### PR TITLE
Skip danger on non-PR pipelines and run-all-tests on bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,8 +395,7 @@ workflows:
             matches:
               pattern: "^release/.*$"
               value: << pipeline.git.branch >>
-        - not:
-            equal: [ bump, << pipeline.parameters.action >> ]
+        - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
       - runtest
       - api-tester

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ workflows:
   version: 2
 
   # =============================================================
-  # run-all-tests: Runs on every push except release branches
+  # run-all-tests: Runs on every push except release branches and bump
   # =============================================================
   run-all-tests:
     when:
@@ -395,6 +395,8 @@ workflows:
             matches:
               pattern: "^release/.*$"
               value: << pipeline.git.branch >>
+        - not:
+            equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
       - runtest
       - api-tester
@@ -509,9 +511,21 @@ workflows:
           <<: *release-tags
 
   danger:
+    when:
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
       - revenuecat/danger:
           ruby_version: "3.2"
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^release\/.*/
+            tags:
+              ignore: /.*/ 
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,9 +523,8 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release\/.*/
             tags:
-              ignore: /.*/ 
+              ignore: /.*/
 
   weekly-run-workflow:
     when:


### PR DESCRIPTION
- [x] Two small CI workflow filter changes to reduce unnecessary job runs.

### Changes

**`danger` workflow — only run on PR commits**
- Added a `when` clause requiring `action == build` (excludes `bump` and `upgrade-hybrid-common` API triggers) and `trigger_source != scheduled_pipeline`.
- Added branch filters to ignore `main` and tags, so the job only fires on PR branch pushes (including `release/*` branches, which create PRs).

**`run-all-tests` workflow — only run on regular builds**
- Added `equal: [build, action]` to the existing `when` clause so the full test suite doesn't run when non-build actions (`bump`, `upgrade-hybrid-common`) are triggered.