### PR TITLE
Enable the use of `all-tests-succeeded` as the only required status check for merging PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,20 +324,12 @@ jobs:
             automatic_release:<< pipeline.parameters.automatic >>
 
   all-tests-succeeded:
-    description: "Gate job: succeeds only when all test jobs pass"
-    docker:
-      - image: cimg/base:stable
-    resource_class: small
-    steps:
-      - run: echo "All tests succeeded"
-
-  all-tasks-passed:
     description: "Gate job: required status check for merging PRs"
     docker:
       - image: cimg/base:stable
     resource_class: small
     steps:
-      - run: echo "All tasks passed"
+      - run: echo "All tests succeeded"
 
   plugin-installation-test:
     description: "Verify cordova plugin add works on both cordova-ios 7 and 8"
@@ -422,7 +414,7 @@ workflows:
           simulator-device: "iPhone 17"
           simulator-os-version: "26.4"
           paramedic-target: "iPhone-17"
-      - all-tasks-passed:
+      - all-tests-succeeded:
           requires:
             - runtest
             - api-tester
@@ -498,14 +490,10 @@ workflows:
           requires:
             - make-release
           <<: *release-tags
-      - all-tasks-passed:
-          requires:
-            - docs-deploy
-          <<: *release-tags
       - revenuecat/merge-release-pr:
           repo_name: cordova-plugin-purchases
           requires:
-            - all-tasks-passed
+            - docs-deploy
           <<: *release-tags
 
   danger:


### PR DESCRIPTION
## Summary

Follow-up to #924. Changes the GitHub required status check from `all-tasks-passed` to `all-tests-succeeded` so that release PRs can always be merged after updating from `main`.

### Problem

In release PRs, after a release succeeds the `deploy` workflow completes `all-tasks-passed`. If new changes are then merged to `main` and the release branch needs to be updated, `all-tasks-passed` will never re-run (it only exists in the `deploy` workflow, which only triggers on tags). This blocks merging the release PR because the required check never reports.

### Changes

- **`run-all-tests` workflow**: Use `all-tests-succeeded` instead of `all-tasks-passed` as the gate job. This job runs on every branch push (except release branches), so it will always report on PRs targeting `main`.
- **`release` workflow**: Already uses `all-tests-succeeded` — no change needed.
- **`deploy` workflow**: Remove the `all-tasks-passed` intermediate job; `revenuecat/merge-release-pr` now depends directly on `docs-deploy`.
- **Remove `all-tasks-passed` job**: No longer used anywhere.

### Workflows after this change

**run-all-tests** (non-release branches):
```
runtest ─────────────────┐
api-tester ──────────────┤
plugin-installation-test ┤
android-integration-test ├─→ all-tests-succeeded  ← GitHub required status check
ios-integration-test (6) ┤
ios-integration-test (7) ┤
ios-integration-test (8) ┘
```

**release** (release branches):
```
runtest ─────────────────┐
api-tester ──────────────┤
plugin-installation-test ┤
android-integration-test ├─→ all-tests-succeeded → hold → tag-current-branch
ios-integration-test (6) ┤
ios-integration-test (7) ┤
ios-integration-test (8) ┘
```

**deploy** (release tags):
```
make-release → docs-deploy → merge-release-pr
```

### After merging

Update the GitHub branch protection required status check from `ci/circleci: all-tasks-passed` to `ci/circleci: all-tests-succeeded`.


Made with [Cursor](https://cursor.com)