### PR TITLE
Remove update_fastlane from before_all

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,6 @@ versions_path = './VERSIONS.md'
 
 before_all do
   setup_circle_ci
-  update_fastlane
 end
 
 desc "Bump version, edit changelog, and create pull request"


### PR DESCRIPTION
Removes the top-level Fastfile's `update_fastlane` call from `before_all`, matching RevenueCat/purchases-unity#912.

When CI runs fastlane through Bundler, `update_fastlane` can install a newer fastlane version out-of-band and clean up the version pinned by `Gemfile.lock`. After fastlane restarts itself, `bundle exec` can then fail with `Could not find fastlane-X.Y.Z in locally installed gems`.

Bundler/dependency PRs should remain the source of truth for fastlane updates.

Related: RevenueCat/purchases-unity#912

Validation: `ruby -c fastlane/Fastfile`