### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   macos: circleci/macos@2.3.6
   android: circleci/android@2.5.0
-  revenuecat: revenuecat/sdks-common-config@3.20.0
+  revenuecat: revenuecat/sdks-common-config@3.21.2
 
 aliases:
   base-mac-job: &base-mac-job


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.
