### PR TITLE
chore: bump fastlane-plugin-revenuecat_internal to unblock hybrid bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: dab67655d71eaf08b40f74339e4bb17d16436c32
+  revision: 9b928b6ca92e965ecb7d63edb810e9343975f3de
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
### Motivation
Hybrid version bumps crash in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass`, because the plugin looked up a removed `bc8` key in purchases-android's `libs.versions.toml`.

### Summary
- Bump the pinned `fastlane-plugin-revenuecat_internal` revision to `main` HEAD, which includes the fix (RevenueCat/fastlane-plugin-revenuecat_internal#145).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency pin for an internal fastlane plugin; no app runtime or SDK code changes.
> 
> **Overview**
> Pins **`fastlane-plugin-revenuecat_internal`** in `Gemfile.lock` to git revision `9b928b6` (from `dab6765`), pulling in the fix from RevenueCat/fastlane-plugin-revenuecat_internal#145.
> 
> This unblocks **hybrid version bump** automation: the previous plugin revision could crash in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass` after purchases-android removed a `bc8` entry from `libs.versions.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24602527f93deaf7b7763b53fed8781534d1a3b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->