### PR TITLE
feat: add setOnesignalUserID for OneSignal v11+

### DIFF
--- a/apiTester/attributes.ts
+++ b/apiTester/attributes.ts
@@ -14,6 +14,7 @@ function checkAttributes(purchases: Purchases) {
   Purchases.setFBAnonymousID(stringOrNull);
   Purchases.setMparticleID(stringOrNull);
   Purchases.setOnesignalID(stringOrNull);
+  Purchases.setOnesignalUserID(stringOrNull);
   Purchases.setAirshipChannelID(stringOrNull);
   Purchases.setCleverTapID(stringOrNull);
   Purchases.setMixpanelDistinctID(stringOrNull);

--- a/src/android/PurchasesPlugin.java
+++ b/src/android/PurchasesPlugin.java
@@ -445,6 +445,12 @@ public class PurchasesPlugin extends AnnotatedCordovaPlugin {
         callbackContext.success();
     }
 
+    @PluginAction(thread = ExecutionThread.WORKER, actionName = "setOnesignalUserID")
+    private void setOnesignalUserID(String onesignalUserID, CallbackContext callbackContext) {
+        SubscriberAttributesKt.setOnesignalUserID(onesignalUserID);
+        callbackContext.success();
+    }
+
     @PluginAction(thread = ExecutionThread.WORKER, actionName = "setAirshipChannelID")
     private void setAirshipChannelID(String airshipChannelID, CallbackContext callbackContext) {
         SubscriberAttributesKt.setAirshipChannelID(airshipChannelID);

--- a/src/ios/PurchasesPlugin+Attribution.swift
+++ b/src/ios/PurchasesPlugin+Attribution.swift
@@ -105,6 +105,13 @@ import PurchasesHybridCommon
                                     setFunction: CommonFunctionality.setOnesignalID)
     }
 
+    @objc(setOnesignalUserID:)
+    func setOnesignalUserID(command: CDVInvokedUrlCommand) {
+        self.setSubscriberAttribute(command: command,
+                                    name: "onesignalUserID",
+                                    setFunction: CommonFunctionality.setOnesignalUserID)
+    }
+
     @objc(setAirshipChannelID:)
     func setAirshipChannelID(command: CDVInvokedUrlCommand) {
         self.setSubscriberAttribute(command: command,

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -2043,6 +2043,22 @@ class Purchases {
   }
 
   /**
+   * Subscriber attribute associated with the OneSignal User ID for the user
+   * Required for the RevenueCat OneSignal integration with versions v11.0 and above.
+   *
+   * @param onesignalUserID Empty String or null will delete the subscriber attribute.
+   */
+  public static setOnesignalUserID(onesignalUserID: string | null): void {
+    window.cordova.exec(
+      null,
+      null,
+      PLUGIN_NAME,
+      "setOnesignalUserID",
+      [onesignalUserID]
+    )
+  }
+
+  /**
    * Subscriber attribute associated with the Airship Channel Id for the user
    * Required for the RevenueCat Airship integration
    *

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -2028,9 +2028,10 @@ class Purchases {
 
   /**
    * Subscriber attribute associated with the OneSignal Player Id for the user
-   * Required for the RevenueCat OneSignal integration
+   * Required for the RevenueCat OneSignal integration with OneSignal SDK v4.0 and below
+   * (OneSignal API v9). For OneSignal SDK v5.0 and above, use {@link setOnesignalUserID} instead.
    *
-   * @param onesignalID Empty String or null will delete the subscriber attribute.
+   * @param onesignalID OneSignal Player ID to use in OneSignal integration. Empty String or null will delete the subscriber attribute.
    */
   public static setOnesignalID(onesignalID: string | null): void {
     window.cordova.exec(
@@ -2044,9 +2045,10 @@ class Purchases {
 
   /**
    * Subscriber attribute associated with the OneSignal User ID for the user
-   * Required for the RevenueCat OneSignal integration with versions v11.0 and above.
+   * Required for the RevenueCat OneSignal integration with OneSignal SDK v5.0
+   * and above (OneSignal API v11+).
    *
-   * @param onesignalUserID Empty String or null will delete the subscriber attribute.
+   * @param onesignalUserID OneSignal User ID to use in OneSignal integration. Empty String or null will delete the subscriber attribute.
    */
   public static setOnesignalUserID(onesignalUserID: string | null): void {
     window.cordova.exec(


### PR DESCRIPTION
Adds `Purchases.setOnesignalUserID` to the Cordova plugin. OneSignal v11 and above use a user-centric API where the identifier to send to RevenueCat is the OneSignal user ID rather than the device-centric player ID. The plugin only exposed `setOnesignalID`, which sets the older `$onesignalId` attribute, so apps on newer OneSignal versions had no way to set the correct attribute other than calling `setAttributes` with the raw reserved key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive subscriber-attribute API with no changes to purchase or auth flows; behavior delegates to existing hybrid-common attribute helpers.
> 
> **Overview**
> Adds **`Purchases.setOnesignalUserID`** across the Cordova plugin so apps on OneSignal SDK v5+ (API v11+) can set the user-centric OneSignal ID for RevenueCat’s integration without using raw `setAttributes`.
> 
> The new API is wired through **TypeScript** (`cordova.exec` action `setOnesignalUserID`), **Android** (`SubscriberAttributesKt.setOnesignalUserID`), and **iOS** (`CommonFunctionality.setOnesignalUserID`), matching the pattern used for other attribution subscriber attributes. **`setOnesignalID`** documentation is updated to state it is for OneSignal v4 and below (player ID); v5+ should use **`setOnesignalUserID`**. The api tester exercises the new method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3e42c7ee3c7fe93d2befb22c99b209f95cec31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->