### PR TITLE
Update sdks-common-config orb to v4.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   macos: circleci/macos@2.3.6
   android: circleci/android@2.5.0
-  revenuecat: revenuecat/sdks-common-config@4.6.0
+  revenuecat: revenuecat/sdks-common-config@4.6.1
 
 aliases:
   base-mac-job: &base-mac-job


### PR DESCRIPTION
### Motivation

Keep CI on the latest shared orb release: [v4.6.1](https://github.com/RevenueCat/sdks-circleci-orb/releases/tag/v4.6.1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level CI orb bump only; no application or security-sensitive code changes.
> 
> **Overview**
> Bumps the CircleCI `revenuecat/sdks-common-config` orb from **4.6.0** to **4.6.1**. No other CI or product code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48245306b6db417a536c0a3aac9b1ec3e3a9f6ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->