### PR TITLE
Remove the leftover PurchasesHybridCommon pod on SwiftPM installs

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,7 @@
     </platform>
     <platform name="ios" package="swift">
         <hook type="after_plugin_install" src="scripts/ios/add-swift-support.js" />
+        <hook type="after_plugin_install" src="scripts/ios/remove-stale-pod.js" />
         <config-file target="config.xml" parent="/*">
             <feature name="PurchasesPlugin">
                 <param name="ios-package" value="CDVPurchasesPlugin"/>

--- a/scripts/ios/remove-stale-pod.js
+++ b/scripts/ios/remove-stale-pod.js
@@ -28,22 +28,11 @@ module.exports = function (context) {
             return;
         }
 
-        const podsJsonPath = path.join(platformPath, 'pods.json');
-        const podsJson = readJson(podsJsonPath);
-        const library = podsJson && podsJson.libraries && podsJson.libraries[POD_NAME];
-
-        if (library && library.count > 1) {
-            return;
-        }
-
         if (!removePodFromPodfile(path.join(platformPath, 'Podfile'))) {
             return;
         }
 
-        if (library) {
-            delete podsJson.libraries[POD_NAME];
-            fs.writeFileSync(podsJsonPath, JSON.stringify(podsJson, null, 4));
-        }
+        removePodFromPodsJson(path.join(platformPath, 'pods.json'));
 
         console.log(
             'Removed the ' + POD_NAME + ' pod left over by a previous install. It is now resolved through Swift Package Manager.'
@@ -75,9 +64,17 @@ function removePodFromPodfile(podfilePath) {
     return true;
 }
 
-function readJson(filePath) {
-    if (!fs.existsSync(filePath)) {
-        return null;
+// Keeps cordova's bookkeeping in sync so it stops counting a pod that is no longer in the Podfile.
+function removePodFromPodsJson(podsJsonPath) {
+    if (!fs.existsSync(podsJsonPath)) {
+        return;
     }
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+    const podsJson = JSON.parse(fs.readFileSync(podsJsonPath, 'utf8'));
+    if (!podsJson.libraries || !podsJson.libraries[POD_NAME]) {
+        return;
+    }
+
+    delete podsJson.libraries[POD_NAME];
+    fs.writeFileSync(podsJsonPath, JSON.stringify(podsJson, null, 4));
 }

--- a/scripts/ios/remove-stale-pod.js
+++ b/scripts/ios/remove-stale-pod.js
@@ -1,0 +1,83 @@
+/*
+ * Removes a leftover PurchasesHybridCommon pod after the plugin is installed as a Swift package.
+ *
+ * On cordova-ios 8+ the plugin and PurchasesHybridCommon are resolved through Swift Package
+ * Manager, so no pod is declared. Apps coming from a CocoaPods-based version of this plugin keep
+ * the old `pod 'PurchasesHybridCommon'` line in their Podfile: cordova's iOS uninstall path throws
+ * before it gets to remove it (it reads `<podspec><config>`, which older versions of this plugin
+ * did not declare). Left in place, PurchasesHybridCommon would be built twice, once by CocoaPods
+ * and once by SwiftPM.
+ *
+ * cordova re-runs `pod install` on every prepare, so removing the entry here is enough for it to
+ * disappear from the generated Pods project on the next build.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const POD_NAME = 'PurchasesHybridCommon';
+const PLUGIN_ID = 'cordova-plugin-purchases';
+
+module.exports = function (context) {
+    try {
+        const platformPath = path.join(context.opts.projectRoot, 'platforms', 'ios');
+
+        // Only SwiftPM installs create this directory. On cordova-ios < 8 the pod is the only
+        // source of PurchasesHybridCommon and has to be left alone.
+        if (!fs.existsSync(path.join(platformPath, 'packages', PLUGIN_ID))) {
+            return;
+        }
+
+        const podsJsonPath = path.join(platformPath, 'pods.json');
+        const podsJson = readJson(podsJsonPath);
+        const library = podsJson && podsJson.libraries && podsJson.libraries[POD_NAME];
+
+        if (library && library.count > 1) {
+            return;
+        }
+
+        if (!removePodFromPodfile(path.join(platformPath, 'Podfile'))) {
+            return;
+        }
+
+        if (library) {
+            delete podsJson.libraries[POD_NAME];
+            fs.writeFileSync(podsJsonPath, JSON.stringify(podsJson, null, 4));
+        }
+
+        console.log(
+            'Removed the ' + POD_NAME + ' pod left over by a previous install. It is now resolved through Swift Package Manager.'
+        );
+    } catch (e) {
+        console.error('Warning: could not remove the leftover ' + POD_NAME + ' pod: ' + e.message);
+        console.error(
+            'If the build fails with duplicate ' + POD_NAME + ' symbols, remove its pod entry from platforms/ios/Podfile.'
+        );
+    }
+};
+
+function removePodFromPodfile(podfilePath) {
+    // cordova-ios only writes a Podfile when some plugin contributes CocoaPods entries, so a
+    // project may not have one at all.
+    if (!fs.existsSync(podfilePath)) {
+        return false;
+    }
+
+    const contents = fs.readFileSync(podfilePath, 'utf8');
+    const podLine = new RegExp("^.*\\bpod\\s+'" + POD_NAME + "'.*$\\n?", 'm');
+    if (!podLine.test(contents)) {
+        return false;
+    }
+
+    // `use_frameworks!` is left behind on purpose: other plugins' pods may rely on it, and it is
+    // inert when no pods remain.
+    fs.writeFileSync(podfilePath, contents.replace(podLine, ''));
+    return true;
+}
+
+function readJson(filePath) {
+    if (!fs.existsSync(filePath)) {
+        return null;
+    }
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}


### PR DESCRIPTION
### Motivation

Stacked on #1042. Apps upgrading to the SwiftPM-based plugin on cordova-ios 8 end up building `PurchasesHybridCommon` twice. Upgrading a plugin is remove-then-add, and cordova's iOS uninstall path throws `Cannot convert undefined or null to object` before it removes the pod, because it reads a `<podspec><config>` element this plugin has never declared. The orphaned `pod 'PurchasesHybridCommon'` then sits alongside the Swift package.

The crash predates this work and reproduces on cordova-ios 7 and 8 with the published 8.1.0, so we can't fix it from the manifest: that removal runs against the *old* version's manifest. Cleaning up after install is the only thing that reaches already-published versions.

### Summary

- After an install that went through SwiftPM, drops any leftover `PurchasesHybridCommon` entry from the Podfile and `pods.json`. cordova re-runs `pod install` on every prepare, so it disappears from the Pods project on the next build.
- No-ops on cordova-ios 7 and below, where the pod is the only source of the library.

### Notes

Verified by hand: the 8.1.0 → this-version upgrade on cordova-ios 8 self-heals; cordova-ios 7 keeps its pod; a project with no Podfile, a Podfile holding other plugins' pods, a pod shared with another plugin (`count > 1`), and a corrupt `pods.json` are all left alone or fail soft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-time Podfile/pods.json edits are gated on SwiftPM layout and fail soft; no runtime purchase or auth logic changes.
> 
> **Overview**
> Adds an **`after_plugin_install`** iOS hook that cleans up a leftover **`PurchasesHybridCommon`** CocoaPods entry when the plugin is installed via **Swift Package Manager** on cordova-ios 8+.
> 
> The new **`remove-stale-pod.js`** script runs only if `platforms/ios/packages/cordova-plugin-purchases` exists (SwiftPM path), then strips matching **`pod 'PurchasesHybridCommon'`** lines from **`Podfile`** and removes the library from **`pods.json`** so the next **`pod install`** stops building the dependency twice. On older cordova-ios or when no stale pod is present it no-ops; errors are logged as warnings with manual cleanup guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b89608121c1310bd7fb51cd0abf0906ede5e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->