### PR TITLE
Ship consumer ProGuard rules for PurchasesPlugin (Android)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,8 @@
         </config-file>
         <framework src="com.revenuecat.purchases:purchases-hybrid-common:18.33.1" />
         <framework src="androidx.annotation:annotation:[1.4.0]"/>
+        <framework src="src/android/build-extras-purchases.gradle" custom="true" type="gradleReference" />
+        <asset src="src/android/proguard-cordova-plugin-purchases.txt" target="proguard-cordova-plugin-purchases.txt" />
         <source-file src="src/android/PurchasesPlugin.java" target-dir="src/com/revenuecat/purchases"/>
     </platform>
     <platform name="ios">

--- a/src/android/build-extras-purchases.gradle
+++ b/src/android/build-extras-purchases.gradle
@@ -1,0 +1,13 @@
+// Adds the plugin's ProGuard/R8 keep rules to the app's minification config.
+// The rules file is copied into the app's www assets by the <asset> entry in
+// plugin.xml, mirroring the mechanism used by cordova-annotated-plugin-android.
+android {
+    buildTypes {
+        debug {
+            proguardFiles 'src/main/assets/www/proguard-cordova-plugin-purchases.txt'
+        }
+        release {
+            proguardFiles 'src/main/assets/www/proguard-cordova-plugin-purchases.txt'
+        }
+    }
+}

--- a/src/android/proguard-cordova-plugin-purchases.txt
+++ b/src/android/proguard-cordova-plugin-purchases.txt
@@ -1,0 +1,11 @@
+# Consumer R8/ProGuard rules for cordova-plugin-purchases.
+#
+# Cordova instantiates PurchasesPlugin via Class.forName using the class name
+# declared in res/xml/config.xml, and AnnotatedCordovaPlugin dispatches plugin
+# actions by reflecting over @PluginAction-annotated methods at runtime.
+# Neither is visible to R8/ProGuard, so keep the class name, its no-arg
+# constructor, and the annotated action methods.
+-keep class com.revenuecat.purchases.PurchasesPlugin {
+    <init>();
+    @com.appfeel.cordova.annotated.android.plugin.PluginAction <methods>;
+}


### PR DESCRIPTION
While testing the Android minification fixes in : https://github.com/RevenueCat/purchases-android/pull/3557 in Cordova, nothing was keeping the native references and were minified out of the build. This PR adds a mechanism so we include a custom proguard that actually keeps the plugin java file that actually references the SDK and we set it as an asset, so it's automatically applied to developers apps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time ProGuard wiring only; no runtime logic or auth/data-path changes, though incorrect keep rules could still affect minified Android builds.
> 
> **Overview**
> Fixes **Android R8/ProGuard minification** stripping the Cordova native bridge so `PurchasesPlugin` no longer breaks in release/debug minified builds.
> 
> The plugin now **bundles consumer keep rules** and **applies them automatically** in consuming apps: `plugin.xml` copies `proguard-cordova-plugin-purchases.txt` into app assets and pulls in `build-extras-purchases.gradle`, which adds that file to **debug and release** `proguardFiles`. The rules **keep** `com.revenuecat.purchases.PurchasesPlugin`, its no-arg constructor, and methods annotated with `@PluginAction`—needed because Cordova loads the class by name from `config.xml` and `AnnotatedCordovaPlugin` dispatches actions via reflection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f99712c3ce5988e00e0845db7c1ca44520a205d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->