### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no repo code changes; empty permissions and a reusable workflow limit exposure on fork PRs.
> 
> **Overview**
> Adds a new GitHub Actions workflow **External PR Notifications** that runs when a pull request is **opened**, using **`pull_request_target`** so forked PRs can use repo secrets without running untrusted code.
> 
> The job delegates to the shared **`revenuecat/sdk-github-workflows`** reusable workflow (pinned at **v7**) and passes **`EXTERNAL_PR_SLACK_WEBHOOK_URL`** so the team gets an internal Slack alert for PRs from outside the org. Workflow **`permissions`** are set to **`{}`** so the default token has no scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544f8a08fbd3aa8e6c6ad3c0430d9cc8a3f23890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->